### PR TITLE
feat: 필터링에 따른 봉사 모집 글 개수 카운트 API 구현

### DIFF
--- a/src/main/java/project/volunteer/domain/recruitment/api/RecruitmentController.java
+++ b/src/main/java/project/volunteer/domain/recruitment/api/RecruitmentController.java
@@ -93,4 +93,23 @@ public class RecruitmentController {
         return ResponseEntity.ok(new RecruitmentDetailsResponse("success search recruitment details", dto));
     }
 
+    @GetMapping("/recruitment/count")
+    public ResponseEntity<RecruitmentCountResponse> recruitmentListCount(@RequestParam(required = false) List<String> volunteering_category,
+                                                                         @RequestParam(required = false) String sido,
+                                                                         @RequestParam(required = false) String sigungu,
+                                                                         @RequestParam(required = false) String volunteering_type,
+                                                                         @RequestParam(required = false) String volunteer_type,
+                                                                         @RequestParam(required = false) Boolean is_issued){
+        Long recruitmentsCount = recruitmentQueryDtoRepository.findRecruitmentCountBySearchType(
+                RecruitmentCond.builder()
+                        .category(volunteering_category)
+                        .sido(sido)
+                        .sigungu(sigungu)
+                        .volunteeringType(volunteering_type)
+                        .volunteerType(volunteer_type)
+                        .isIssued(is_issued)
+                        .build());
+        return ResponseEntity.ok(new RecruitmentCountResponse("success count recruitment list", recruitmentsCount));
+    }
+
 }

--- a/src/main/java/project/volunteer/domain/recruitment/api/dto/response/RecruitmentCountResponse.java
+++ b/src/main/java/project/volunteer/domain/recruitment/api/dto/response/RecruitmentCountResponse.java
@@ -1,0 +1,21 @@
+package project.volunteer.domain.recruitment.api.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import project.volunteer.global.common.response.BaseResponse;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecruitmentCountResponse extends BaseResponse {
+
+    private Long totalCnt;
+
+    public RecruitmentCountResponse(String message, Long totalCnt) {
+        super(message);
+        this.totalCnt = totalCnt;
+    }
+}

--- a/src/main/java/project/volunteer/domain/recruitment/dao/queryDto/RecruitmentQueryDtoRepository.java
+++ b/src/main/java/project/volunteer/domain/recruitment/dao/queryDto/RecruitmentQueryDtoRepository.java
@@ -14,5 +14,7 @@ public interface RecruitmentQueryDtoRepository {
     //전체 모집글,이미지,저장소 join 리스트 조회
     Slice<RecruitmentListQuery> findRecruitmentJoinImageBySearchType(Pageable pageable, RecruitmentCond searchType);
 
+    //필터링에 따른 모집글 개수 카운트
+    Long findRecruitmentCountBySearchType(RecruitmentCond searchType);
 }
 

--- a/src/main/java/project/volunteer/domain/recruitment/dao/queryDto/RecruitmentQueryDtoRepositoryImpl.java
+++ b/src/main/java/project/volunteer/domain/recruitment/dao/queryDto/RecruitmentQueryDtoRepositoryImpl.java
@@ -96,6 +96,24 @@ public class RecruitmentQueryDtoRepositoryImpl implements RecruitmentQueryDtoRep
         return checkEndPage(pageable, content);
     }
 
+    @Override
+    public Long findRecruitmentCountBySearchType(RecruitmentCond searchType) {
+        return jpaQueryFactory
+                .select(recruitment.count())
+                .from(recruitment)
+                .where(
+                        containCategory(searchType.getCategory()),
+                        eqSidoCode(searchType.getSido()),
+                        eqSigunguCode(searchType.getSigungu()),
+                        eqVolunteeringType(searchType.getVolunteeringType()),
+                        eqVolunteerType(searchType.getVolunteerType()),
+                        eqIsIssued(searchType.getIsIssued()),
+                        recruitment.isPublished.eq(Boolean.TRUE) //임시저장된 모집글은 제외
+                        //추후 삭제된 게시물 제외 필요.
+                )
+                .fetchOne();
+    }
+
     private List<Day> findDays(Long recruitmentNo){
         return jpaQueryFactory
                 .select(repeatPeriod.day)

--- a/src/main/java/project/volunteer/domain/recruitment/dao/queryDto/dto/RecruitmentCond.java
+++ b/src/main/java/project/volunteer/domain/recruitment/dao/queryDto/dto/RecruitmentCond.java
@@ -1,5 +1,6 @@
 package project.volunteer.domain.recruitment.dao.queryDto.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -29,6 +30,7 @@ public class RecruitmentCond {
     private VolunteerType volunteerType;
     private Boolean isIssued;
 
+    @Builder
     public RecruitmentCond(List<String> category, String sido, String sigungu, String volunteeringType, String volunteerType, Boolean isIssued) {
 
         this.category = Optional.ofNullable(category)

--- a/src/test/java/project/volunteer/domain/recruitment/api/RecruitmentControllerTestForQuery.java
+++ b/src/test/java/project/volunteer/domain/recruitment/api/RecruitmentControllerTestForQuery.java
@@ -53,7 +53,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-class RecruitmentControllerTestForFindAll {
+class RecruitmentControllerTestForQuery {
 
     @Autowired UserRepository userRepository;
     @Autowired ParticipantRepository participantRepository;
@@ -66,7 +66,8 @@ class RecruitmentControllerTestForFindAll {
     @PersistenceContext EntityManager em;
     @Autowired MockMvc mockMvc;
 
-    private static final String FINDALL_URL = "/recruitment";
+    private static final String FIND_ALL_URL = "/recruitment";
+    private static final String COUNT_URL = "/recruitment/count";
     private static User saveUser;
     private List<Long> deletePlanS3ImageNo = new ArrayList<>();
     private void clear() {
@@ -204,7 +205,7 @@ class RecruitmentControllerTestForFindAll {
 
         //when & then
         mockMvc.perform(
-                get(FINDALL_URL).params(info))
+                get(FIND_ALL_URL).params(info))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -222,9 +223,42 @@ class RecruitmentControllerTestForFindAll {
 
         //when & then
         mockMvc.perform(
-                        get(FINDALL_URL).params(info))
+                        get(FIND_ALL_URL).params(info))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
 
+    @Test
+    @WithUserDetails(value = "1234", setupBefore = TestExecutionEvent.TEST_EXECUTION) //@BeforeEach 어노테이션부터 활성화하도록!!
+    public void 모집글_전체카운트_모든필터링_성공() throws Exception {
+        //init
+        setData();
+
+        //given
+        MultiValueMap<String,String> info = new LinkedMultiValueMap();
+        info.add("volunteering_category", "001");
+        info.add("sido", "11");
+        info.add("sigungu","1111");
+        info.add("volunteering_type", VolunteeringType.IRREG.name());
+        info.add("volunteer_type", "1"); //all
+        info.add("is_issued", "true");
+
+        //when & then
+        mockMvc.perform(
+                        get(COUNT_URL).params(info))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @WithUserDetails(value = "1234", setupBefore = TestExecutionEvent.TEST_EXECUTION) //@BeforeEach 어노테이션부터 활성화하도록!!
+    public void 모집글_전체카운트_빈필터링_성공() throws Exception {
+        //init
+        setData();
+
+        mockMvc.perform(
+                        get(COUNT_URL))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
 }

--- a/src/test/java/project/volunteer/domain/recruitment/dao/queryDto/RecruitmentQueryDtoRepositoryImplTest.java
+++ b/src/test/java/project/volunteer/domain/recruitment/dao/queryDto/RecruitmentQueryDtoRepositoryImplTest.java
@@ -235,8 +235,7 @@ class RecruitmentQueryDtoRepositoryImplTest {
 
     @Test
     public void 모집글_전체조회_임시저장글제외_Slice(){
-        //givenE
-
+        //given
         List<String> category = new ArrayList<>();
         String sido = null;
         String sigungu = null;
@@ -254,6 +253,42 @@ class RecruitmentQueryDtoRepositoryImplTest {
         Assertions.assertThat(result.getContent().size()).isEqualTo(15);
         Assertions.assertThat(result.hasNext()).isFalse();
         Assertions.assertThat(result.getNumber()).isEqualTo(0);
+    }
+
+    @Test
+    public void 모집글_전체조회_모든필터링_카운트(){
+        //given
+        List<String> category = Arrays.asList("001");
+        String sido = "11";
+        String sigungu = "1111";
+        String volunteeringType = VolunteeringType.IRREG.name();
+        String volunteerType = VolunteerType.ALL.getLegacyCode();
+        Boolean isIssued = true;
+        RecruitmentCond cond = new RecruitmentCond(category, sido, sigungu, volunteeringType, volunteerType, isIssued);
+
+        //then
+        Long count = recruitmentQueryDtoRepository.findRecruitmentCountBySearchType(cond);
+
+        //then
+        Assertions.assertThat(count).isEqualTo(5);
+    }
+
+    @Test
+    public void 모집글_전체조회_빈필터링_카운트(){
+        //given
+        List<String> category = null;
+        String sido = null;
+        String sigungu = null;
+        String volunteeringType = null;
+        String volunteerType =null;
+        Boolean isIssued = null;
+        RecruitmentCond cond = new RecruitmentCond(category, sido, sigungu, volunteeringType, volunteerType, isIssued);
+
+        //when
+        Long count = recruitmentQueryDtoRepository.findRecruitmentCountBySearchType(cond);
+
+        //then
+        Assertions.assertThat(count).isEqualTo(15);
     }
 
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 코드 변경, 폴더 구조 변경 
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Feature/VOL-44/recruitment-filter -> dev

### 기능 추가
* QueryDSL를 사용한 동적 필터링에 따른 모집 글 리스트 count 

### 변경 사항
* RecruitmentCond DTO List 필드 null 검증 로직 추가

### 테스트 코드
* 모집 글 리스트 카운트 repository 통합 테스트 코드 작성
* 모집 글 리스트 카운트 controller 통합 테스트 코드 작성

close #11 
