### PR TITLE
refactor: 봉사 모집글 상세조회 DTO 수정 사항을 반영하다.

### DIFF
--- a/src/main/java/project/volunteer/domain/image/dao/ImageRepository.java
+++ b/src/main/java/project/volunteer/domain/image/dao/ImageRepository.java
@@ -16,7 +16,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     @EntityGraph(attributePaths = {"storage"})
     @Query("select im from Image im " +
             "where im.realWorkCode = :code and im.no = :no and im.isDeleted=project.volunteer.global.common.component.IsDeleted.N")
-    public Optional<Image> findByEGStorageByCodeAndNo(@Param("code") RealWorkCode realWorkCode, @Param("no") Long no);
+    public Optional<Image> findEGStorageByCodeAndNo(@Param("code") RealWorkCode realWorkCode, @Param("no") Long no);
 
     @Query("select img from Image img " +
             "where img.realWorkCode=:code and img.no=:no and img.isDeleted=project.volunteer.global.common.component.IsDeleted.N")

--- a/src/main/java/project/volunteer/domain/participation/application/ParticipationServiceImpl.java
+++ b/src/main/java/project/volunteer/domain/participation/application/ParticipationServiceImpl.java
@@ -73,7 +73,7 @@ public class ParticipationServiceImpl implements ParticipationService{
 
         Long loginUserNo = SecurityUtil.getLoginUserNo();
 
-        Participant findState = participantRepository.findByState(recruitmentNo, loginUserNo, State.JOIN_REQUEST)
+        Participant findState = participantRepository.findByRecruitmentNoAndParticipantNoAndState(recruitmentNo, loginUserNo, State.JOIN_REQUEST)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_STATE,
                         String.format("UserNo = [%d], RecruitmentNo = [%d], State = [%s]",
                                 loginUserNo, recruitmentNo, State.JOIN_REQUEST.name())));
@@ -115,7 +115,7 @@ public class ParticipationServiceImpl implements ParticipationService{
         Recruitment recruitment = isActivatediRecruitment(recruitmentNo, String.format("RecruitmentNo to Deport = [%d]", recruitmentNo));
         isRecruitmentOwner(recruitment);
 
-        Participant findState = participantRepository.findByState(recruitmentNo, userNo, State.JOIN_APPROVAL)
+        Participant findState = participantRepository.findByRecruitmentNoAndParticipantNoAndState(recruitmentNo, userNo, State.JOIN_APPROVAL)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_STATE,
                         String.format("UserNo = [%d], RecruitmentNo = [%d]", userNo, recruitmentNo)));
 

--- a/src/main/java/project/volunteer/domain/participation/dao/ParticipantRepository.java
+++ b/src/main/java/project/volunteer/domain/participation/dao/ParticipantRepository.java
@@ -14,7 +14,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     //참여자 매핑 정보, 참여자 정보 쿼리 한번에 가져오기(left join)
     @EntityGraph(attributePaths = {"participant"})
-    List<Participant> findEGParticipantByRecruitment_RecruitmentNo(Long recruitmentNo);
+    List<Participant> findEGParticipantByRecruitment_RecruitmentNoAndStateIn(Long recruitmentNo, List<State> states);
 
     Optional<Participant> findByRecruitment_RecruitmentNoAndParticipant_UserNo(Long recruitmentNo, Long userId);
 
@@ -24,7 +24,8 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
             "where p.recruitment.recruitmentNo = :recruitmentNo " +
             "and p.participant.userNo = :userNo " +
             "and p.state = :state")
-    Optional<Participant> findByState(@Param("recruitmentNo")Long recruitmentNo, @Param("userNo")Long userNo, @Param("state")State state);
+    Optional<Participant> findByRecruitmentNoAndParticipantNoAndState(@Param("recruitmentNo")Long recruitmentNo, @Param("userNo")Long userNo,
+                                                                      @Param("state")State state);
 
     //봉사 모집글 팀원 신청가능한 인원 반환 쿼리
     @Query("select count(p) from Participant p " +

--- a/src/main/java/project/volunteer/domain/recruitment/api/dto/request/RecruitmentRequest.java
+++ b/src/main/java/project/volunteer/domain/recruitment/api/dto/request/RecruitmentRequest.java
@@ -50,7 +50,7 @@ public class RecruitmentRequest {
     private String hourFormat;
 
     @NotEmpty
-    @Pattern(regexp = "^(0[1-9]|1[012]):(0[1-9]|[12345][0-9])$")
+    @Pattern(regexp = "^(0[1-9]|1[012]):(0[0-9]|[12345][0-9])$")
     private String startTime;
 
     @Range(min=1, max = 24)

--- a/src/main/java/project/volunteer/domain/recruitment/application/RecruitmentDtoServiceImpl.java
+++ b/src/main/java/project/volunteer/domain/recruitment/application/RecruitmentDtoServiceImpl.java
@@ -11,6 +11,7 @@ import project.volunteer.domain.image.domain.RealWorkCode;
 import project.volunteer.domain.participation.dao.ParticipantRepository;
 import project.volunteer.domain.participation.domain.Participant;
 import project.volunteer.domain.recruitment.application.dto.ParticipantDetails;
+import project.volunteer.domain.recruitment.application.dto.ParticipantState;
 import project.volunteer.domain.recruitment.application.dto.WriterDetails;
 import project.volunteer.domain.recruitment.domain.VolunteeringType;
 import project.volunteer.domain.recruitment.dto.PictureDetails;
@@ -25,7 +26,9 @@ import project.volunteer.domain.user.domain.User;
 import project.volunteer.global.common.component.State;
 import project.volunteer.global.error.exception.BusinessException;
 import project.volunteer.global.error.exception.ErrorCode;
+import project.volunteer.global.util.SecurityUtil;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -45,75 +48,129 @@ public class RecruitmentDtoServiceImpl implements RecruitmentDtoService{
     @Override
     public RecruitmentDetails findRecruitment(Long no) {
 
-        //모집글 정보 + 모집글 작성자 정보 -> 쿼리1번
+        //모집글 정보 + 모집글 작성자 정보 -> 쿼리 1번
         Recruitment findRecruitment = recruitmentRepository.findWriterEG(no).orElseThrow(()
                 -> new BusinessException(ErrorCode.NOT_EXIST_RECRUITMENT, String.format("Search Recruitment NO = [%d]", no)));
         User writer = findRecruitment.getWriter();
 
-        //1. 모집글 정보 dto 생성
+        //1. 모집글 정보 dto 세팅
         RecruitmentDetails dto = new RecruitmentDetails(findRecruitment);
 
-        //모집글 이미지(image + storage) -> 쿼리 1번
-        //모집글 이미지는 반드시 존재!
-        Optional<Image> recruitmentImage = imageRepository.findByEGStorageByCodeAndNo(RealWorkCode.RECRUITMENT, no);
-        //2. 모집글 이미지 dto 세팅
-        if(recruitmentImage.isPresent())
-            dto.setPicture(new PictureDetails(recruitmentImage.get().getStaticImageName(), recruitmentImage.get().getStorage().getImagePath()));
+        //2. 모집글 이미지 dto 세팅 -> 쿼리 1번
+        makeRecruitmentImageDto(dto, no);
 
-        //작성자 프로필 이미지(image + storage) -> 쿼리 1번
-        //upload 이미지이므로 존재할 수도 있고, 없을수 있음.!
-        Optional<Image> userUploadImage = imageRepository.findByEGStorageByCodeAndNo(RealWorkCode.USER, writer.getUserNo());
-        //3. 모집글 작성자 dto 세팅
-        dto.setAuthor(createWriterDto(writer, userUploadImage));
+        //3. 모집글 작성자 dto 세팅 -> 쿼리 1번
+        makeWriterDto(dto, writer);
 
+        //4. 정기 모집글 반복주기 dto 세팅
         //"정기"일 경우 반복주기 검색 -> 쿼리 1번
         if(findRecruitment.getVolunteeringType().equals(VolunteeringType.REG)){
-            List<RepeatPeriod> repeatPeriodDto = repeatPeriodRepository.findByRecruitment_RecruitmentNo(no);
-            //4. 반복주기 dto 세팅
-            dto.setRepeatPeriod(createRepeatPeriodDto(repeatPeriodDto));
+            makeRepeatPeriodDto(dto, no);
         }
 
-        //참여자 매핑 정보 + 참여자 정보 -> 쿼리 1번
-        List<Participant> participants = participantRepository.findEGParticipantByRecruitment_RecruitmentNo(no);
-        //5. 참여자 dto 세팅
-        //upload 이미지가 아닐 경우에도 참여자 수만큼 N번 쿼리 발생(움..)
-        //최적화가 필요할거 같은 부분!
-        dto.setCurrentVolunteer(createParticipantsDto(participants));
+        //5. 모집글 참여자 dto 세팅 -> 참여자 정보(쿼리1번) + 참여자 이미지 검색(참여자 수 N)
+        makeParticipantsDto(dto, no);
+
+        //6. 로그인 사용자 상태 판별 -> 쿼리 2번
+        dto.setStatus(decideUserState(findRecruitment));
 
         return dto;
     }
 
-    private WriterDetails createWriterDto(User writer, Optional<Image> userUploadImage) {
+    private void makeRecruitmentImageDto(RecruitmentDetails dto, Long recruitmentNo){
+        //모집글 이미지(image + storage) -> 쿼리 1번
+        //모집글 이미지는 반드시 존재!
+        Optional<Image> recruitmentImage = imageRepository.findEGStorageByCodeAndNo(RealWorkCode.RECRUITMENT, recruitmentNo);
+        if(recruitmentImage.isPresent())
+            dto.setPicture(new PictureDetails(recruitmentImage.get().getStaticImageName(), recruitmentImage.get().getStorage().getImagePath()));
+    }
+
+    private void makeWriterDto(RecruitmentDetails dto, User writer) {
+        //작성자 프로필 이미지(image + storage) -> 쿼리 1번
+        //upload 이미지이므로 존재할 수도 있고, 없을수 있음.!
+        Optional<Image> userUploadImage = imageRepository.findEGStorageByCodeAndNo(RealWorkCode.USER, writer.getUserNo());
+
         WriterDetails author  = null;
         if(userUploadImage.isPresent()){ //유저 프로필이 업로드 이미지인 경우
             author = new WriterDetails(writer.getNickName(), userUploadImage.get().getStorage().getImagePath());
         }else{                           //oauth 기본 프로필인 경우
             author = new WriterDetails(writer.getNickName(), writer.getPicture());
         }
-       return author;
+        dto.setAuthor(author);
     }
 
-    private RepeatPeriodDetails createRepeatPeriodDto(List<RepeatPeriod> repeatPeriods){
+    private void makeRepeatPeriodDto(RecruitmentDetails dto, Long recruitmentNo){
+        List<RepeatPeriod> repeatPeriods = repeatPeriodRepository.findByRecruitment_RecruitmentNo(recruitmentNo);
+
         String period = repeatPeriods.get(0).getPeriod().getViewName();
         String week = (period.equals(Period.MONTH))?(repeatPeriods.get(0).getWeek().getViewName()):"";
         List<String> days = repeatPeriods.stream().map(r -> r.getDay().getViewName()).collect(Collectors.toList());
-        return new RepeatPeriodDetails(period, week, days);
+
+        dto.setRepeatPeriod(new RepeatPeriodDetails(period, week, days));
     }
 
-    private List<ParticipantDetails> createParticipantsDto(List<Participant> participants) {
+    private void makeParticipantsDto(RecruitmentDetails dto, Long recruitmentNo) {
+        //참여자 정보 + (approval, request) 상태 조회 -> 쿼리 1번
+        List<Participant> participants = participantRepository.findEGParticipantByRecruitment_RecruitmentNoAndStateIn(
+                recruitmentNo, List.of(State.JOIN_REQUEST, State.JOIN_APPROVAL));
 
-        List<ParticipantDetails> dtos = new ArrayList<>();
+        List<ParticipantDetails> approvedList = new ArrayList<>();
+        List<ParticipantDetails> requiredList = new ArrayList<>();
+
         participants.stream()
                 .forEach(p -> {
-                    User participant = p.getParticipant();
-                    Boolean isApproved = (p.getState().equals(State.JOIN_APPROVAL))?true:false;
-                    Optional<Image> userUploadImage = imageRepository.findByEGStorageByCodeAndNo(RealWorkCode.USER, participant.getUserNo());
-                    if(userUploadImage.isPresent()){  //유저 프로필이 업로드 이미지인 경우
-                        dtos.add(new ParticipantDetails(participant.getNickName(), userUploadImage.get().getStorage().getImagePath(), isApproved));
-                    }else {                           //유저 프로필이 기본(oauth image)인 경우
-                        dtos.add(new ParticipantDetails(participant.getNickName(), participant.getPicture(), isApproved));
+                    User participant = p.getParticipant(); //EntityGraph 인해 쿼리 발생 X
+                    ParticipantDetails details = null;
+
+                    //업로드 한 이미지 인지 판단 - 참여자(승인,요청) 인원수 만큼 쿼리 발생
+                    //upload 이미지가 아닐 경우에도 참여자 N명 만큼 쿼리 발생
+                    //최적화가 필요할거 같은 부분!
+                    Optional<Image> userUploadImage = imageRepository.findEGStorageByCodeAndNo(RealWorkCode.USER, participant.getUserNo());
+                    if(userUploadImage.isPresent()){
+                        details = new ParticipantDetails(
+                                participant.getUserNo(), participant.getNickName(), userUploadImage.get().getStorage().getImagePath());
+                    }else {
+                        details = new ParticipantDetails(participant.getUserNo(), participant.getNickName(), participant.getPicture());
+                    }
+
+                    if(p.getState().equals(State.JOIN_APPROVAL)){
+                        approvedList.add(details);
+                    }else{
+                        requiredList.add(details);
                     }
                 });
-        return dtos;
+
+        dto.setApprovalVolunteer(approvedList);
+        dto.setRequiredVolunteer(requiredList);
     }
+
+    private String decideUserState(Recruitment findRecruitment){
+        //모집 마감 상태
+        if(findRecruitment.getVolunteeringTimeTable().getEndDay().isBefore(LocalDate.now()) ||
+                participantRepository.countAvailableParticipants(findRecruitment.getRecruitmentNo())==findRecruitment.getVolunteerNum()) {
+            return ParticipantState.DONE.name();
+        }
+
+        Long loginUserNo = SecurityUtil.getLoginUserNo();
+        Optional<Participant> findState = participantRepository.findByRecruitment_RecruitmentNoAndParticipant_UserNo(
+                findRecruitment.getRecruitmentNo(), loginUserNo);
+
+        //신청 가능 상태(재신청 포함)
+        if(!findState.isPresent() || List.of(State.JOIN_CANCEL, State.QUIT, State.DEPORT).contains(findState.get().getState())){
+            return ParticipantState.AVAILABLE.name();
+        }
+
+        //승인 대기 상태
+        if(findState.get().getState().equals(State.JOIN_REQUEST)){
+            return ParticipantState.PENDING.name();
+        }
+
+        //승인 완료 상태
+        if(findState.get().getState().equals(State.JOIN_APPROVAL)){
+            return ParticipantState.APPROVED.name();
+        }
+
+        return "";
+    }
+
 }

--- a/src/main/java/project/volunteer/domain/recruitment/application/dto/ParticipantDetails.java
+++ b/src/main/java/project/volunteer/domain/recruitment/application/dto/ParticipantDetails.java
@@ -4,13 +4,12 @@ import lombok.*;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
-@ToString
+@NoArgsConstructor
 public class ParticipantDetails {
 
+    private Long userNo;
     private String nickName;
     private String imageUrl;
-    private Boolean isApproved;
 
 }

--- a/src/main/java/project/volunteer/domain/recruitment/application/dto/ParticipantState.java
+++ b/src/main/java/project/volunteer/domain/recruitment/application/dto/ParticipantState.java
@@ -1,0 +1,12 @@
+package project.volunteer.domain.recruitment.application.dto;
+
+public enum ParticipantState {
+
+    AVAILABLE("신청 가능"), PENDING("승인 대기"), APPROVED("승인 완료"), DONE("모집 마감"), NOTLOGIN("비 로그인")
+    ;
+
+    private String des;
+    ParticipantState(String dec) {
+        this.des = dec;
+    }
+}

--- a/src/main/java/project/volunteer/domain/recruitment/application/dto/RecruitmentDetails.java
+++ b/src/main/java/project/volunteer/domain/recruitment/application/dto/RecruitmentDetails.java
@@ -9,6 +9,7 @@ import project.volunteer.domain.recruitment.dto.PictureDetails;
 import project.volunteer.domain.recruitment.dto.RepeatPeriodDetails;
 
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -25,7 +26,8 @@ public class RecruitmentDetails {
     private String volunteeringType;
     private String volunteerType;
     private Integer volunteerNum;
-    private List<ParticipantDetails> currentVolunteer;
+    private List<ParticipantDetails> approvalVolunteer = new ArrayList<>(); //승인된 참여자 리스트
+    private List<ParticipantDetails> requiredVolunteer = new ArrayList<>(); //참여 요청한 참여자 리스트
     private WriterDetails author;
     private String startDay;
     private String endDay;
@@ -36,6 +38,7 @@ public class RecruitmentDetails {
     private PictureDetails picture;
     private String title;
     private String content;
+    private String status;
 
     public RecruitmentDetails(Recruitment recruitment){
         this.no = recruitment.getRecruitmentNo();

--- a/src/main/java/project/volunteer/global/config/SecurityConfig.java
+++ b/src/main/java/project/volunteer/global/config/SecurityConfig.java
@@ -63,8 +63,14 @@ public class SecurityConfig {
 			 // 커스텀 필터 등록
             .apply(new MyCustomDsl())
 			.and()
-			
+
 			.authorizeRequests()
+
+					//봉사 모집글 관련
+					.antMatchers(HttpMethod.POST, "/recruitment").hasAuthority("USER")
+					.antMatchers(HttpMethod.DELETE, "/recruitment/*").hasAuthority("USER")
+					.antMatchers(HttpMethod.GET, "/recruitment", "/recruitment/count").permitAll()
+					.antMatchers(HttpMethod.GET,"/recruitment/*").hasAuthority("USER")
 
 					//팀원 관리
 					.antMatchers(HttpMethod.POST, "/recruitment/join").hasAuthority("USER")
@@ -73,12 +79,8 @@ public class SecurityConfig {
 					.antMatchers(HttpMethod.POST, "/recruitment/kick").hasAuthority("USER")
 
 			.anyRequest().permitAll()
-			/*
-			// 게시글 등록, 수정, 삭제
-			.antMatchers(HttpMethod.POST,"/recruitment").hasAuthority("USER")
-			.antMatchers(HttpMethod.PUT,"/recruitment").hasAuthority("USER")
-			.antMatchers(HttpMethod.DELETE,"/recruitment").hasAuthority("USER")
 
+			/*
 			// 일정 등록, 수정, 삭제
 			.antMatchers(HttpMethod.POST,"/schedule").hasAuthority("USER")
 			.antMatchers(HttpMethod.PUT,"/schedule").hasAuthority("USER")

--- a/src/test/java/project/volunteer/domain/recruitment/api/RecruitmentControllerTestForQuery.java
+++ b/src/test/java/project/volunteer/domain/recruitment/api/RecruitmentControllerTestForQuery.java
@@ -171,6 +171,33 @@ class RecruitmentControllerTestForQuery {
         }
         clear();
     }
+    private List<Long> addParticipant(int count, State state, Long recruitmentNo){
+        List<Long> participantNoList = new ArrayList<>();
+
+        for(int i=0;i<count;i++){
+            User joinUser = userRepository.save(User.builder()
+                    .id("1234" + i)
+                    .password("1234" + i)
+                    .nickName("nickname" + i)
+                    .email("email" + i + "@gmail.com")
+                    .gender(Gender.M)
+                    .birthDay(LocalDate.now())
+                    .picture("picture" + i)
+                    .joinAlarmYn(true).beforeAlarmYn(true).noticeAlarmYn(true)
+                    .role(Role.USER)
+                    .provider("kakao").providerId("1234" + i)
+                    .build());
+
+            participantRepository.save(Participant.builder()
+                    .participant(joinUser)
+                    .recruitment(recruitmentRepository.findById(recruitmentNo).get())
+                    .state(state)
+                    .build());
+
+            participantNoList.add(joinUser.getUserNo());
+        }
+        return participantNoList;
+    }
     @BeforeEach
     public void initUser(){
         saveUser = userRepository.save(User.builder()
@@ -276,6 +303,9 @@ class RecruitmentControllerTestForQuery {
     public void 모집글_상세조회_성공() throws Exception {
         //given
         setData();
+        addParticipant(100, State.JOIN_APPROVAL, saveRecruitmentNoList.get(1));
+        addParticipant(10, State.JOIN_REQUEST, saveRecruitmentNoList.get(1));
+        clear();
 
         //when && then
         mockMvc.perform(get(FIND_URL + saveRecruitmentNoList.get(1)))

--- a/src/test/java/project/volunteer/domain/recruitment/api/RecruitmentControllerTestForWrite.java
+++ b/src/test/java/project/volunteer/domain/recruitment/api/RecruitmentControllerTestForWrite.java
@@ -8,7 +8,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
@@ -183,7 +182,7 @@ class RecruitmentControllerTestForWrite {
         //finally(s3 업로드 이미지 삭제)
         //테스트 코드에서 저장한 모집글 게시물은 하나니깐 전체 조회해도 반드시 하나만 나올것이다. (좋지 않은 코드 같은데...)
         Recruitment recruitment = recruitmentRepository.findAll().get(0);
-        Image image = imageRepository.findByEGStorageByCodeAndNo(RealWorkCode.RECRUITMENT, recruitment.getRecruitmentNo()).get();
+        Image image = imageRepository.findEGStorageByCodeAndNo(RealWorkCode.RECRUITMENT, recruitment.getRecruitmentNo()).get();
         fileService.deleteFile(image.getStorage().getFakeImageName());
     }
 
@@ -212,7 +211,7 @@ class RecruitmentControllerTestForWrite {
         //finally(s3 업로드 이미지 삭제)
         //테스트 코드에서 저장한 모집글 게시물은 하나니깐 전체 조회해도 반드시 하나만 나올것이다. (좋지 않은 코드 같은데...)
         Recruitment recruitment = recruitmentRepository.findAll().get(0);
-        Image image = imageRepository.findByEGStorageByCodeAndNo(RealWorkCode.RECRUITMENT, recruitment.getRecruitmentNo()).get();
+        Image image = imageRepository.findEGStorageByCodeAndNo(RealWorkCode.RECRUITMENT, recruitment.getRecruitmentNo()).get();
         fileService.deleteFile(image.getStorage().getFakeImageName());
     }
 


### PR DESCRIPTION
close #22 
close #28 

# 구현 사항
* 쿼리 메소드 네이밍 변경
* 로그인 사용자의 봉사 모집 글 신청 상태 판별 기능 구현
* 봉사 모집 글 저장 간 봉사 시간 정규 표현 식 버그 수정

# 논의하고 싶은 사항
* 봉사 모집 글 상세 API에 인증 사용자 접근 시 JWT 토큰 검증을 인터셉터로 구현하는게 좋은 지 고민이네요. 시큐리티 필터의 로직과 완전히 중복될거라 생각이 듭니다.



