### PR TITLE
refactor: 봉사 모집 글 참여자 리스트 조회 쿼리 최적화를 한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,8 @@ application-local.yml
 application-oauth.yml
 application-smtp.yml
 application-prod.yml
+application-test.yml
+application-perfomance.yml
+application-*.yml
 .gitmodules
 yml-config/

--- a/src/main/java/project/volunteer/domain/image/domain/Image.java
+++ b/src/main/java/project/volunteer/domain/image/domain/Image.java
@@ -14,7 +14,9 @@ import java.util.Optional;
 
 @Getter
 @Entity
-@Table(name = "vlt_image")
+@Table(name = "vlt_image", indexes = {
+        @Index(name = "idx_no_realworkcode", columnList = "no, realwork_code")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Image extends BaseTimeEntity {
 

--- a/src/main/java/project/volunteer/domain/participation/dao/ParticipantRepository.java
+++ b/src/main/java/project/volunteer/domain/participation/dao/ParticipantRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import project.volunteer.domain.participation.dao.dto.ParticipantStateDetails;
 import project.volunteer.domain.participation.domain.Participant;
 import project.volunteer.global.common.component.State;
 
@@ -15,6 +16,19 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     //참여자 매핑 정보, 참여자 정보 쿼리 한번에 가져오기(left join)
     @EntityGraph(attributePaths = {"participant"})
     List<Participant> findEGParticipantByRecruitment_RecruitmentNoAndStateIn(Long recruitmentNo, List<State> states);
+
+    @Query("select new project.volunteer.domain.participation.dao.dto.ParticipantStateDetails" +
+            "(p.state, u.userNo, u.nickName, coalesce(s.imagePath, u.picture)) " +
+            "from Participant p " +
+            "join p.participant as u " +
+            "left join Image i " +
+            "on u.userNo = i.no " +
+            "and i.realWorkCode=project.volunteer.domain.image.domain.RealWorkCode.USER " +
+            "and i.isDeleted=project.volunteer.global.common.component.IsDeleted.N " +
+            "left join i.storage as s " +
+            "where p.recruitment.recruitmentNo=:no " +
+            "and p.state in :states ")
+    List<ParticipantStateDetails> findParticipantsByOptimization(@Param("no") Long recruitmentNo, @Param("states") List<State> states);
 
     Optional<Participant> findByRecruitment_RecruitmentNoAndParticipant_UserNo(Long recruitmentNo, Long userId);
 

--- a/src/main/java/project/volunteer/domain/participation/dao/dto/ParticipantStateDetails.java
+++ b/src/main/java/project/volunteer/domain/participation/dao/dto/ParticipantStateDetails.java
@@ -1,0 +1,25 @@
+package project.volunteer.domain.participation.dao.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import project.volunteer.global.common.component.State;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ParticipantStateDetails {
+
+    private State state;
+    private Long userNo;
+    private String nickName;
+    private String imageUrl;
+
+    public ParticipantStateDetails(State state, Long userNo, String nickName, String imageUrl){
+        this.state = state;
+        this.userNo = userNo;
+        this.nickName = nickName;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/project/volunteer/domain/recruitment/api/RecruitmentController.java
+++ b/src/main/java/project/volunteer/domain/recruitment/api/RecruitmentController.java
@@ -25,6 +25,7 @@ import project.volunteer.domain.repeatPeriod.application.RepeatPeriodService;
 import project.volunteer.domain.repeatPeriod.application.dto.RepeatPeriodParam;
 import project.volunteer.domain.sehedule.application.ScheduleService;
 import project.volunteer.domain.sehedule.application.dto.ScheduleParamReg;
+import project.volunteer.global.aop.LogExecutionTime;
 
 import javax.validation.Valid;
 import java.util.HashMap;
@@ -113,6 +114,7 @@ public class RecruitmentController {
         return ResponseEntity.ok(result);
     }
 
+//    @LogExecutionTime
     @GetMapping("/recruitment/{no}")
     public ResponseEntity<RecruitmentDetails> recruitmentDetails(@PathVariable Long no){
 

--- a/src/main/java/project/volunteer/domain/recruitment/application/RecruitmentDtoServiceImpl.java
+++ b/src/main/java/project/volunteer/domain/recruitment/application/RecruitmentDtoServiceImpl.java
@@ -9,6 +9,7 @@ import project.volunteer.domain.image.dao.ImageRepository;
 import project.volunteer.domain.image.domain.Image;
 import project.volunteer.domain.image.domain.RealWorkCode;
 import project.volunteer.domain.participation.dao.ParticipantRepository;
+import project.volunteer.domain.participation.dao.dto.ParticipantStateDetails;
 import project.volunteer.domain.participation.domain.Participant;
 import project.volunteer.domain.recruitment.application.dto.ParticipantDetails;
 import project.volunteer.domain.recruitment.application.dto.ParticipantState;
@@ -69,7 +70,8 @@ public class RecruitmentDtoServiceImpl implements RecruitmentDtoService{
         }
 
         //5. 모집글 참여자 dto 세팅 -> 참여자 정보(쿼리1번) + 참여자 이미지 검색(참여자 수 N)
-        makeParticipantsDto(dto, no);
+        //makeParticipantsDto(dto, no);
+        makeOptimizedParticipantsDto(dto, no);
 
         //6. 로그인 사용자 상태 판별 -> 쿼리 2번
         dto.setStatus(decideUserState(findRecruitment));
@@ -137,6 +139,28 @@ public class RecruitmentDtoServiceImpl implements RecruitmentDtoService{
                         approvedList.add(details);
                     }else{
                         requiredList.add(details);
+                    }
+                });
+
+        dto.setApprovalVolunteer(approvedList);
+        dto.setRequiredVolunteer(requiredList);
+    }
+
+    private void makeOptimizedParticipantsDto(RecruitmentDetails dto, Long recruitmentNo){
+
+        List<ParticipantDetails> approvedList = new ArrayList<>();
+        List<ParticipantDetails> requiredList = new ArrayList<>();
+
+        //최적화한 쿼리(쿼리 1번)
+        List<ParticipantStateDetails> participants = participantRepository.findParticipantsByOptimization(recruitmentNo,
+                List.of(State.JOIN_REQUEST, State.JOIN_APPROVAL));
+
+        participants.stream()
+                .forEach(p -> {
+                    if(p.getState().equals(State.JOIN_REQUEST)){
+                        requiredList.add(new ParticipantDetails(p.getUserNo(), p.getNickName(), p.getImageUrl()));
+                    }else{
+                        approvedList.add(new ParticipantDetails(p.getUserNo(), p.getNickName(), p.getImageUrl()));
                     }
                 });
 

--- a/src/main/java/project/volunteer/global/aop/LogAspect.java
+++ b/src/main/java/project/volunteer/global/aop/LogAspect.java
@@ -1,0 +1,38 @@
+package project.volunteer.global.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+import java.time.LocalDateTime;
+
+@Component
+@Aspect
+@Slf4j
+public class LogAspect {
+
+    //메서드 실행 전, 후 시간 공유
+    @Around("@annotation(LogExecutionTime)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        StopWatch stopWatch = new StopWatch();
+
+        stopWatch.start();
+        Object proceed = joinPoint.proceed();
+        stopWatch.stop();
+
+        long totalTimeMillis = stopWatch.getTotalTimeMillis();
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String methodName = signature.getMethod().getName();
+
+        log.info("실행 메서드 : {}, 실행 시간 : {}ms", methodName, totalTimeMillis);
+
+        return proceed;
+    }
+
+}

--- a/src/main/java/project/volunteer/global/aop/LogExecutionTime.java
+++ b/src/main/java/project/volunteer/global/aop/LogExecutionTime.java
@@ -1,0 +1,11 @@
+package project.volunteer.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecutionTime {
+}

--- a/src/test/java/project/volunteer/domain/recruitment/api/RecruitmentControllerTestForQuery.java
+++ b/src/test/java/project/volunteer/domain/recruitment/api/RecruitmentControllerTestForQuery.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
@@ -30,6 +31,7 @@ import project.volunteer.domain.recruitment.domain.VolunteeringType;
 import project.volunteer.domain.repeatPeriod.application.RepeatPeriodService;
 import project.volunteer.domain.repeatPeriod.application.dto.RepeatPeriodParam;
 import project.volunteer.domain.repeatPeriod.domain.Day;
+import project.volunteer.domain.storage.dao.StorageRepository;
 import project.volunteer.domain.storage.domain.Storage;
 import project.volunteer.domain.user.dao.UserRepository;
 import project.volunteer.domain.user.domain.Gender;
@@ -61,6 +63,7 @@ class RecruitmentControllerTestForQuery {
     @Autowired ParticipantRepository participantRepository;
     @Autowired RecruitmentRepository recruitmentRepository;
     @Autowired ImageRepository imageRepository;
+    @Autowired StorageRepository storageRepository;
     @Autowired RecruitmentService recruitmentService;
     @Autowired RepeatPeriodService repeatPeriodService;
     @Autowired ImageService imageService;
@@ -99,7 +102,7 @@ class RecruitmentControllerTestForQuery {
         String organizationName ="name";
         String details = "details";
         Float latitude = 3.2F , longitude = 3.2F;
-        Integer volunteerNum = 5;
+        Integer volunteerNum = 9999;
         String startDay = "01-01-2000";
         String endDay = "01-01-2000";
         String hourFormat = HourFormat.AM.name();
@@ -187,6 +190,21 @@ class RecruitmentControllerTestForQuery {
                     .role(Role.USER)
                     .provider("kakao").providerId("1234" + i)
                     .build());
+
+            Storage storage = storageRepository.save(
+                    Storage.builder()
+                            .imagePath("1234" + i)
+                            .fakeImageName("1234" + i)
+                            .realImageName("1234" + i)
+                            .extName(".jpg")
+                            .build());
+
+            Image save = imageRepository.save(
+                    Image.builder()
+                            .realWorkCode(RealWorkCode.USER)
+                            .no(joinUser.getUserNo())
+                            .build());
+            save.setStorage(storage);
 
             participantRepository.save(Participant.builder()
                     .participant(joinUser)
@@ -303,8 +321,8 @@ class RecruitmentControllerTestForQuery {
     public void 모집글_상세조회_성공() throws Exception {
         //given
         setData();
-        addParticipant(100, State.JOIN_APPROVAL, saveRecruitmentNoList.get(1));
-        addParticipant(10, State.JOIN_REQUEST, saveRecruitmentNoList.get(1));
+        addParticipant(200, State.JOIN_APPROVAL, saveRecruitmentNoList.get(1));
+        addParticipant(100, State.JOIN_REQUEST, saveRecruitmentNoList.get(1));
         clear();
 
         //when && then

--- a/src/test/java/project/volunteer/domain/recruitment/performance/MockData.java
+++ b/src/test/java/project/volunteer/domain/recruitment/performance/MockData.java
@@ -1,0 +1,195 @@
+package project.volunteer.domain.recruitment.performance;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+import project.volunteer.domain.image.dao.ImageRepository;
+import project.volunteer.domain.image.domain.Image;
+import project.volunteer.domain.image.domain.RealWorkCode;
+import project.volunteer.domain.participation.dao.ParticipantRepository;
+import project.volunteer.domain.participation.domain.Participant;
+import project.volunteer.domain.recruitment.dao.RecruitmentRepository;
+import project.volunteer.domain.recruitment.domain.Recruitment;
+import project.volunteer.domain.recruitment.domain.VolunteerType;
+import project.volunteer.domain.recruitment.domain.VolunteeringCategory;
+import project.volunteer.domain.recruitment.domain.VolunteeringType;
+import project.volunteer.domain.repeatPeriod.dao.RepeatPeriodRepository;
+import project.volunteer.domain.repeatPeriod.domain.Day;
+import project.volunteer.domain.repeatPeriod.domain.Period;
+import project.volunteer.domain.repeatPeriod.domain.RepeatPeriod;
+import project.volunteer.domain.repeatPeriod.domain.Week;
+import project.volunteer.domain.storage.dao.StorageRepository;
+import project.volunteer.domain.storage.domain.Storage;
+import project.volunteer.domain.user.dao.UserRepository;
+import project.volunteer.domain.user.domain.Gender;
+import project.volunteer.domain.user.domain.Role;
+import project.volunteer.domain.user.domain.User;
+import project.volunteer.global.common.component.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Transactional
+@SpringBootTest
+public class MockData {
+
+    @Autowired RecruitmentRepository recruitmentRepository;
+    @Autowired RepeatPeriodRepository repeatPeriodRepository;
+    @Autowired ImageRepository imageRepository;
+    @Autowired StorageRepository storageRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired ParticipantRepository participantRepository;
+    User ownerUser;
+    List<Recruitment> saveRecruitmentNoList = new ArrayList<>();
+    @BeforeEach
+    public void init() {
+        ownerUser = userRepository.save(User.builder()
+                .id("1234")
+                .password("1234")
+                .nickName("nickname")
+                .email("email@gmail.com")
+                .gender(Gender.M)
+                .birthDay(LocalDate.now())
+                .picture("picture")
+                .joinAlarmYn(true).beforeAlarmYn(true).noticeAlarmYn(true)
+                .role(Role.USER)
+                .provider("kakao").providerId("1234")
+                .build());
+
+        for (int i = 0; i < 10; i++) {
+            Recruitment saveRecruitment = recruitmentRepository.save(
+                    Recruitment.builder()
+                            .title("1234" + i)
+                            .content("1234" + i)
+                            .volunteeringCategory(VolunteeringCategory.EDUCATION)
+                            .volunteeringType(VolunteeringType.REG)
+                            .volunteerType(VolunteerType.ALL)
+                            .volunteerNum(9999)
+                            .isIssued(true)
+                            .organizationName("1234" + i)
+                            .address(
+                                    Address.builder()
+                                            .sido("1" + i)
+                                            .sigungu("1234" + i)
+                                            .details("1234" + i)
+                                            .build()
+                            )
+                            .coordinate(
+                                    Coordinate.builder()
+                                            .longitude(3.2F)
+                                            .latitude(3.2F)
+                                            .build()
+                            )
+                            .timetable(
+                                    Timetable.builder()
+                                            .progressTime(3)
+                                            .startDay(LocalDate.now())
+                                            .endDay(LocalDate.now())
+                                            .startTime(LocalTime.now())
+                                            .hourFormat(HourFormat.AM)
+                                            .build()
+                            )
+                            .isPublished(true)
+                            .build());
+            saveRecruitment.setWriter(ownerUser);
+
+            RepeatPeriod savePeriod = repeatPeriodRepository.save(
+                    RepeatPeriod.builder()
+                            .period(Period.MONTH)
+                            .week(Week.FIRST)
+                            .day(Day.SUN)
+                            .build());
+            savePeriod.setRecruitment(saveRecruitment);
+
+            //현재 사용중인 이미지
+            Storage saveStorage = storageRepository.save(
+                    Storage.builder()
+                            .imagePath("1234" + i)
+                            .fakeImageName("1234" + i)
+                            .realImageName("1234" + i)
+                            .extName(".jpg")
+                            .build());
+            Image saveImage = imageRepository.save(
+                    Image.builder()
+                            .realWorkCode(RealWorkCode.RECRUITMENT)
+                            .no(saveRecruitment.getRecruitmentNo())
+                            .build());
+            saveImage.setStorage(saveStorage);
+
+            saveRecruitmentNoList.add(saveRecruitment);
+        }
+    }
+
+//    @Rollback(value = false)
+//    @Test
+//    public void 성능테스트를위한_목데이터_setup() throws Exception {
+//        //만건 insert
+//        for(int i=0;i<10;i++){
+//            addParticipant(5000, State.JOIN_APPROVAL, saveRecruitmentNoList.get(i).getRecruitmentNo());
+//            addParticipant(5000, State.JOIN_REQUEST, saveRecruitmentNoList.get(i).getRecruitmentNo());
+//        }
+//    }
+
+    private void addParticipant(int count, State state, Long recruitmentNo){
+        for(int i=0;i<count;i++){
+            User joinUser = userRepository.save(User.builder()
+                    .id("1234" + i)
+                    .password("1234" + i)
+                    .nickName("nickname" + i)
+                    .email("email" + i + "@gmail.com")
+                    .gender(Gender.M)
+                    .birthDay(LocalDate.now())
+                    .picture("picture" + i)
+                    .joinAlarmYn(true).beforeAlarmYn(true).noticeAlarmYn(true)
+                    .role(Role.USER)
+                    .provider("kakao").providerId("1234" + i)
+                    .build());
+
+            Storage storage = storageRepository.save(
+                    Storage.builder()
+                            .imagePath("1234" + i)
+                            .fakeImageName("1234" + i)
+                            .realImageName("1234" + i)
+                            .extName(".jpg")
+                            .build());
+
+            Image save = imageRepository.save(
+                    Image.builder()
+                            .realWorkCode(RealWorkCode.USER)
+                            .no(joinUser.getUserNo())
+                            .build());
+            save.setStorage(storage);
+
+            //이전에 사용하던 이미지(삭제된 이미지)
+            Storage deletedStorage = storageRepository.save(
+                    Storage.builder()
+                            .imagePath("deleted" + i)
+                            .fakeImageName("deleted" + i)
+                            .realImageName("deleted" + i)
+                            .extName(".jpg")
+                            .build());
+
+            deletedStorage.setDeleted();
+            Image deletedImage = imageRepository.save(
+                    Image.builder()
+                            .realWorkCode(RealWorkCode.USER)
+                            .no(joinUser.getUserNo())
+                            .build());
+            deletedImage.setStorage(deletedStorage);
+            deletedImage.setDeleted();
+
+
+            participantRepository.save(Participant.builder()
+                    .participant(joinUser)
+                    .recruitment(recruitmentRepository.findById(recruitmentNo).get())
+                    .state(state)
+                    .build());
+        }
+    }
+}

--- a/src/test/java/project/volunteer/domain/recruitment/performance/RecruitmentDetailPerformanceTest.java
+++ b/src/test/java/project/volunteer/domain/recruitment/performance/RecruitmentDetailPerformanceTest.java
@@ -1,0 +1,27 @@
+package project.volunteer.domain.recruitment.performance;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class RecruitmentDetailPerformanceTest {
+    @Autowired MockMvc mockMvc;
+
+    final String FIND_URL = "/recruitment/";
+//    @Test
+//    public void recruitment_details_refer_performance_test() throws Exception {
+//
+//        mockMvc.perform(get(FIND_URL + 1))
+//                .andExpect(status().isOk());
+//    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  profiles:
+    active: test
+    #active: performance
+    include:
+      - aws
+      - oauth
+      - smtp
+  messages:
+    basename: messages
+
+  #Spring boot 2.6 이상 & swagger 3.0 사용시 호완 오류
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+logging:
+  level:
+    root: info


### PR DESCRIPTION
close #30 

# 문제 상황
* 봉사 모집 글 참여자 리스트 조회 시 참여자 수만큼 업로드 이미지 조회 쿼리 발생

# 해결한 방법
* 참여자 리스트 정보를 하나의 쿼리로 리팩토링
* 이미지 테이블의 no, realWorkCode 컬럼을 인덱스로 설정하여 조회 성능 향상
     * 이미지 테이블 조회 시 no, realWorkCode 컬럼을 조건으로 사용하는 빈도가 높고, 카디널리티가 높아 인덱스로 설정했습니다.

# 집중해서 리뷰 맡고 싶은 부분
* 실제 조회 쿼리 최적화가 이루어졌는지
* 쿼리 성능을 좀 더 높일 수 있는 방안이 있는지