### PR TITLE
feat: 일정 신청 간 발생한 동시성 이슈를 비관적 락을 이용해 해결하기

### DIFF
--- a/src/main/java/project/volunteer/domain/scheduleParticipation/service/ParticipationServiceConcurrent.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/service/ParticipationServiceConcurrent.java
@@ -1,0 +1,187 @@
+package project.volunteer.domain.scheduleParticipation.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.volunteer.domain.participation.dao.ParticipantRepository;
+import project.volunteer.domain.participation.domain.Participant;
+import project.volunteer.domain.scheduleParticipation.dao.ScheduleParticipationRepository;
+import project.volunteer.domain.scheduleParticipation.domain.ScheduleParticipation;
+import project.volunteer.domain.sehedule.dao.ScheduleRepository;
+import project.volunteer.domain.sehedule.domain.Schedule;
+import project.volunteer.global.common.component.ParticipantState;
+import project.volunteer.global.error.exception.BusinessException;
+import project.volunteer.global.error.exception.ErrorCode;
+
+/**
+ * 동시성 테스트를 위한 Service
+ */
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ParticipationServiceConcurrent {
+
+    private final ScheduleRepository scheduleRepository;
+    private final ParticipantRepository participantRepository;
+    private final ScheduleParticipationRepository scheduleParticipationRepository;
+
+    @Transactional
+    public void participateWithoutLock(Long recruitmentNo, Long scheduleNo, Long loginUserNo) {
+        //일정 검증(존재 여부, 모집 기간)
+        Schedule findSchedule = isActiveScheduleWithoutLock(scheduleNo);
+
+        /**
+         * - 별다른 추가 필드 없이 쿼리를 통해 참가자 인원 수 체크하는 방식
+         * - 동시성 이슈가 발생(두 번의 갱신 분실 문제)
+         */
+        Integer activeParticipantNum = scheduleParticipationRepository.countActiveParticipant(scheduleNo);
+        if(findSchedule.getVolunteerNum() == activeParticipantNum){
+            throw new BusinessException(ErrorCode.INSUFFICIENT_CAPACITY,
+                    String.format("ScheduleNo = [%d], Active participant num = [%d]", findSchedule.getScheduleNo(), findSchedule.getCurrentVolunteerNum()));
+        }
+
+        scheduleParticipationRepository.findByUserNoAndScheduleNo(loginUserNo, scheduleNo)
+                .ifPresentOrElse(
+                        sp -> {
+                            //중복 신청 검증(일정 참여중, 일정 참여 취소 요청)
+                            if(sp.isEqualState(ParticipantState.PARTICIPATING) || sp.isEqualState(ParticipantState.PARTICIPATION_CANCEL)){
+                                throw new BusinessException(ErrorCode.DUPLICATE_PARTICIPATION,
+                                        String.format("ScheduleNo = [%d], UserNo = [%d], State = [%s]", findSchedule.getScheduleNo(), loginUserNo, sp.getState().name()));
+                            }
+
+                            //재신청
+                            sp.updateState(ParticipantState.PARTICIPATING);
+                        },
+                        () ->{
+                            //신규 신청
+                            Participant findParticipant =
+                                    participantRepository.findByRecruitment_RecruitmentNoAndParticipant_UserNo(recruitmentNo, loginUserNo)
+                                            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_PARTICIPATION,
+                                                    String.format("ScheduleNo = [%d], UserNo = [%d]", scheduleNo, loginUserNo)));
+
+                            ScheduleParticipation createSP =
+                                    ScheduleParticipation.createScheduleParticipation(findSchedule, findParticipant, ParticipantState.PARTICIPATING);
+                            scheduleParticipationRepository.save(createSP);
+                        }
+                );
+    }
+
+    @Transactional
+    public void participateWithOPTIMSTICLock(Long recruitmentNo, Long scheduleNo, Long loginUserNo) {
+        //일정 검증(존재 여부, 모집 기간)
+        Schedule findSchedule = isActiveScheduleWithOPTIMSTICLock(scheduleNo);
+
+        if(findSchedule.isFullParticipant()) {
+            throw new BusinessException(ErrorCode.INSUFFICIENT_CAPACITY,
+                    String.format("ScheduleNo = [%d], Active participant num = [%d]", findSchedule.getScheduleNo(), findSchedule.getCurrentVolunteerNum()));
+        }
+
+        scheduleParticipationRepository.findByUserNoAndScheduleNo(loginUserNo, scheduleNo)
+                .ifPresentOrElse(
+                        sp -> {
+                            //중복 신청 검증(일정 참여중, 일정 참여 취소 요청)
+                            if (sp.isEqualState(ParticipantState.PARTICIPATING) || sp.isEqualState(ParticipantState.PARTICIPATION_CANCEL)) {
+                                throw new BusinessException(ErrorCode.DUPLICATE_PARTICIPATION,
+                                        String.format("ScheduleNo = [%d], UserNo = [%d], State = [%s]", findSchedule.getScheduleNo(), loginUserNo, sp.getState().name()));
+                            }
+                            //재신청
+                            sp.updateState(ParticipantState.PARTICIPATING);
+                            },
+                        () -> {
+                            //신규 신청
+                            Participant findParticipant =
+                                    participantRepository.findByRecruitment_RecruitmentNoAndParticipant_UserNo(recruitmentNo, loginUserNo)
+                                            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_PARTICIPATION,
+                                                    String.format("ScheduleNo = [%d], UserNo = [%d]", scheduleNo, loginUserNo)));
+
+                            ScheduleParticipation createSP =
+                                    ScheduleParticipation.createScheduleParticipation(findSchedule, findParticipant, ParticipantState.PARTICIPATING);
+                            scheduleParticipationRepository.save(createSP);
+                        });
+
+        findSchedule.increaseParticipant();
+    }
+
+    @Transactional
+    public void participateWithPERSSIMITIC_WRITE_Lock(Long recruitmentNo, Long scheduleNo, Long loginUserNo) {
+        //일정 검증(존재 여부, 모집 기간)
+        Schedule findSchedule = isActiveScheduleWithPERSSIMITIC_WRITE_Lock(scheduleNo);
+
+        if(findSchedule.isFullParticipant()){
+            throw new BusinessException(ErrorCode.INSUFFICIENT_CAPACITY,
+                    String.format("ScheduleNo = [%d], Active participant num = [%d]", findSchedule.getScheduleNo(), findSchedule.getCurrentVolunteerNum()));
+        }
+
+        scheduleParticipationRepository.findByUserNoAndScheduleNo(loginUserNo, scheduleNo)
+                .ifPresentOrElse(
+                        sp -> {
+                            //중복 신청 검증(일정 참여중, 일정 참여 취소 요청)
+                            if (sp.isEqualState(ParticipantState.PARTICIPATING) || sp.isEqualState(ParticipantState.PARTICIPATION_CANCEL)) {
+                                throw new BusinessException(ErrorCode.DUPLICATE_PARTICIPATION,
+                                        String.format("ScheduleNo = [%d], UserNo = [%d], State = [%s]", findSchedule.getScheduleNo(), loginUserNo, sp.getState().name()));
+                            }
+                            //재신청
+                            sp.updateState(ParticipantState.PARTICIPATING);
+                        },
+                        () -> {
+                            //신규 신청
+                            Participant findParticipant =
+                                    participantRepository.findByRecruitment_RecruitmentNoAndParticipant_UserNo(recruitmentNo, loginUserNo)
+                                            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_PARTICIPATION,
+                                                    String.format("ScheduleNo = [%d], UserNo = [%d]", scheduleNo, loginUserNo)));
+
+                            ScheduleParticipation createSP =
+                                    ScheduleParticipation.createScheduleParticipation(findSchedule, findParticipant, ParticipantState.PARTICIPATING);
+                            scheduleParticipationRepository.save(createSP);
+                        });
+
+        findSchedule.increaseParticipant();
+    }
+
+    private Schedule isActiveScheduleWithoutLock(Long scheduleNo){
+        //일정 조회(삭제되지 않은지만 검증)
+        Schedule findSchedule = scheduleRepository.findValidSchedule(scheduleNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_SCHEDULE,
+                        String.format("Schedule to participant = [%d]", scheduleNo)));
+
+        //일정 마감 일자 조회
+        if(!findSchedule.isAvailableDate()){
+            throw new BusinessException(ErrorCode.EXPIRED_PERIOD_SCHEDULE,
+                    String.format("ScheduleNo = [%d], participation period = [%s]", findSchedule.getScheduleNo(), findSchedule.getScheduleTimeTable().getEndDay().toString()));
+        }
+
+        return findSchedule;
+    }
+    private Schedule isActiveScheduleWithOPTIMSTICLock(Long scheduleNo){
+        //일정 조회(삭제되지 않은지만 검증)
+        Schedule findSchedule = scheduleRepository.findValidScheduleWithOPTIMSTICLock(scheduleNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_SCHEDULE,
+                        String.format("Schedule to participant = [%d]", scheduleNo)));
+
+        //일정 마감 일자 조회
+        if(!findSchedule.isAvailableDate()){
+            throw new BusinessException(ErrorCode.EXPIRED_PERIOD_SCHEDULE,
+                    String.format("ScheduleNo = [%d], participation period = [%s]", findSchedule.getScheduleNo(), findSchedule.getScheduleTimeTable().getEndDay().toString()));
+        }
+
+        return findSchedule;
+    }
+    private Schedule isActiveScheduleWithPERSSIMITIC_WRITE_Lock(Long scheduleNo){
+        //일정 조회(삭제되지 않은지만 검증)
+        Schedule findSchedule = scheduleRepository.findValidScheduleWithPESSIMISTIC_WRITE_Lock(scheduleNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_SCHEDULE,
+                        String.format("Schedule to participant = [%d]", scheduleNo)));
+
+        //일정 마감 일자 조회
+        if(!findSchedule.isAvailableDate()){
+            throw new BusinessException(ErrorCode.EXPIRED_PERIOD_SCHEDULE,
+                    String.format("ScheduleNo = [%d], participation period = [%s]", findSchedule.getScheduleNo(), findSchedule.getScheduleTimeTable().getEndDay().toString()));
+        }
+
+        return findSchedule;
+    }
+
+
+}

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationServiceImpl.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationServiceImpl.java
@@ -28,7 +28,7 @@ public class ScheduleParticipationServiceImpl implements ScheduleParticipationSe
     @Transactional
     public void participate(Long recruitmentNo, Long scheduleNo, Long loginUserNo) {
         //일정 검증(존재 여부, 모집 기간)
-        Schedule findSchedule = isActiveSchedule(scheduleNo);
+        Schedule findSchedule = isActiveScheduleWithPERSSIMITIC_WRITE_Lock(scheduleNo);
 
         //모집 인원 검증
         if(findSchedule.isFullParticipant()){
@@ -61,7 +61,6 @@ public class ScheduleParticipationServiceImpl implements ScheduleParticipationSe
                         }
                 );
 
-        //일정 참가자 수 증가
         findSchedule.increaseParticipant();
     }
 
@@ -121,6 +120,20 @@ public class ScheduleParticipationServiceImpl implements ScheduleParticipationSe
     private Schedule isActiveSchedule(Long scheduleNo){
         //일정 조회(삭제되지 않은지만 검증)
         Schedule findSchedule = scheduleRepository.findValidSchedule(scheduleNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_SCHEDULE,
+                        String.format("Schedule to participant = [%d]", scheduleNo)));
+
+        //일정 마감 일자 조회
+        if(!findSchedule.isAvailableDate()){
+            throw new BusinessException(ErrorCode.EXPIRED_PERIOD_SCHEDULE,
+                    String.format("ScheduleNo = [%d], participation period = [%s]", findSchedule.getScheduleNo(), findSchedule.getScheduleTimeTable().getEndDay().toString()));
+        }
+
+        return findSchedule;
+    }
+    private Schedule isActiveScheduleWithPERSSIMITIC_WRITE_Lock(Long scheduleNo){
+        //일정 조회(삭제되지 않은지만 검증)
+        Schedule findSchedule = scheduleRepository.findValidScheduleWithPESSIMISTIC_WRITE_Lock(scheduleNo)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_SCHEDULE,
                         String.format("Schedule to participant = [%d]", scheduleNo)));
 

--- a/src/main/java/project/volunteer/domain/sehedule/dao/ScheduleRepository.java
+++ b/src/main/java/project/volunteer/domain/sehedule/dao/ScheduleRepository.java
@@ -1,10 +1,12 @@
 package project.volunteer.domain.sehedule.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import project.volunteer.domain.sehedule.domain.Schedule;
 
+import javax.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +21,19 @@ public interface ScheduleRepository extends JpaRepository<Schedule,Long> ,Custom
             "where s.scheduleNo=:no " +
             "and s.isDeleted=project.volunteer.global.common.component.IsDeleted.N")
     public Optional<Schedule> findValidSchedule(@Param("no") Long scheduleNo);
+    @Query("select s " +
+            "from Schedule s " +
+            "where s.scheduleNo=:no " +
+            "and s.isDeleted=project.volunteer.global.common.component.IsDeleted.N")
+    @Lock(LockModeType.OPTIMISTIC) //낙관적 락 사용
+    public Optional<Schedule> findValidScheduleWithOPTIMSTICLock(@Param("no") Long scheduleNo);
+    @Query("select s " +
+            "from Schedule s " +
+            "where s.scheduleNo=:no " +
+            "and s.isDeleted=project.volunteer.global.common.component.IsDeleted.N")
+    @Lock(LockModeType.PESSIMISTIC_WRITE) //비관적 락 사용
+    public Optional<Schedule> findValidScheduleWithPESSIMISTIC_WRITE_Lock(@Param("no") Long scheduleNo);
+
 
     @Query("select s " +
             "from Schedule s " +

--- a/src/main/java/project/volunteer/domain/sehedule/domain/Schedule.java
+++ b/src/main/java/project/volunteer/domain/sehedule/domain/Schedule.java
@@ -36,6 +36,9 @@ public class Schedule extends BaseTimeEntity {
 
     @Column(name = "current_volunteer_num", nullable = false)
     private Integer currentVolunteerNum;
+    //낙관적 락 사용
+//    @Version
+//    private Integer version;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "is_deleted", length = 1, nullable = false)

--- a/src/test/java/project/volunteer/domain/scheduleParticipation/service/ConcurrentTest.java
+++ b/src/test/java/project/volunteer/domain/scheduleParticipation/service/ConcurrentTest.java
@@ -1,0 +1,200 @@
+package project.volunteer.domain.scheduleParticipation.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.annotation.Rollback;
+import project.volunteer.domain.participation.dao.ParticipantRepository;
+import project.volunteer.domain.participation.domain.Participant;
+import project.volunteer.domain.recruitment.dao.RecruitmentRepository;
+import project.volunteer.domain.recruitment.domain.Recruitment;
+import project.volunteer.domain.recruitment.domain.VolunteerType;
+import project.volunteer.domain.recruitment.domain.VolunteeringCategory;
+import project.volunteer.domain.recruitment.domain.VolunteeringType;
+import project.volunteer.domain.scheduleParticipation.dao.ScheduleParticipationRepository;
+import project.volunteer.domain.scheduleParticipation.domain.ScheduleParticipation;
+import project.volunteer.domain.sehedule.dao.ScheduleRepository;
+import project.volunteer.domain.sehedule.domain.Schedule;
+import project.volunteer.domain.user.dao.UserRepository;
+import project.volunteer.domain.user.domain.Gender;
+import project.volunteer.domain.user.domain.Role;
+import project.volunteer.domain.user.domain.User;
+import project.volunteer.global.common.component.*;
+import project.volunteer.global.error.exception.BusinessException;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Slf4j
+public class ConcurrentTest {
+    @Autowired UserRepository userRepository;
+    @Autowired RecruitmentRepository recruitmentRepository;
+    @Autowired ScheduleRepository scheduleRepository;
+    @Autowired ParticipantRepository participantRepository;
+    @Autowired
+    ParticipationServiceConcurrent participateService;
+    @Autowired ScheduleParticipationRepository scheduleParticipationRepository;
+
+    User writer;
+    Recruitment saveRecruitment;
+    Schedule saveSchedule;
+    @BeforeEach
+    void init(){
+        //작성자 저장
+        User writerUser = User.createUser("1234", "1234", "1234", "1234", Gender.M, LocalDate.now(), "1234",
+                true, true, true, Role.USER, "kakao", "1234", null);
+        writer = userRepository.save(writerUser);
+
+        //모집글 저장
+        Recruitment createRecruitment = Recruitment.createRecruitment("title", "content", VolunteeringCategory.CULTURAL_EVENT, VolunteeringType.IRREG,
+                VolunteerType.TEENAGER, 3, true, "organization",
+                Address.createAddress("11", "1111","details"), Coordinate.createCoordinate(3.2F, 3.2F),
+                Timetable.createTimetable(LocalDate.now(), LocalDate.now().plusMonths(3), HourFormat.AM, LocalTime.now(), 3), true);
+        createRecruitment.setWriter(writer);
+        saveRecruitment = recruitmentRepository.save(createRecruitment);
+
+        //일정 저장
+        Schedule createSchedule = Schedule.createSchedule(
+                Timetable.createTimetable(
+                        LocalDate.now().plusMonths(1), LocalDate.now().plusMonths(1),
+                        HourFormat.AM, LocalTime.now(), 3),
+                "content", "organization",
+                Address.createAddress("11", "1111", "details"), 1);
+        createSchedule.setRecruitment(saveRecruitment);
+        saveSchedule = scheduleRepository.save(createSchedule);
+    }
+
+    @Test
+    @DisplayName("일정 참여 모집 인원은 1명인데, 동시성 이슈로 인해 3명의 사용자 모두 참여가 된다.")
+    public void concurrentParticipationWithoutLock() throws InterruptedException {
+        //given
+        final int numberOfThreads = 3;
+
+        CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        List<Participant> participants = addTeamMember(numberOfThreads);
+
+        //when
+        for(int i=0;i<numberOfThreads;i++){
+            Participant participant = participants.get(i);
+
+            executorService.execute(() -> {
+                try{
+                    participateService.participateWithoutLock(saveRecruitment.getRecruitmentNo(), saveSchedule.getScheduleNo(), participant.getParticipant().getUserNo());
+                }finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        //then
+        List<ScheduleParticipation> findSP = scheduleParticipationRepository.findBySchedule_ScheduleNo(saveSchedule.getScheduleNo());
+        assertThat(findSP.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("낙관적 락을 통해 동시성 문제를 해결해보자.")
+    public void concurrentParticipationWithOPTIMSTICLock() throws InterruptedException {
+        //given
+        final int numberOfThreads = 3;
+
+        CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        List<Participant> participants = addTeamMember(numberOfThreads);
+
+        //when
+        for(int i=0;i<numberOfThreads;i++){
+            Participant participant = participants.get(i);
+
+            executorService.execute(() -> {
+                try{
+                    participateService.participateWithOPTIMSTICLock(saveRecruitment.getRecruitmentNo(), saveSchedule.getScheduleNo(), participant.getParticipant().getUserNo());
+                }catch (ObjectOptimisticLockingFailureException e){
+                    log.info("동시성 문제 발견");
+                    /**
+                     * 예외가 밸생해야됨.
+                     * 예외 발생 시 "인원 마감" message 를 사용자에게 보여준다. -> 동시성 해결됬나?!
+                     * "데드락" 발생(s-lock, x-lock)!!!(외래키가 있는 테이블에서는 낙관적 락으로 동시성을 해결 불가능!!)
+                     * 만약 데드락이 발생하지 않더라도,여유자리가 많은 남은 상황에서 동시에 신청할 때는 예외가 발생하면 안됨.
+                     * 또한 데드락이 발생하지 않고 마지막 인원의 신청자가 update 해주기 위해서 상태 Enum을 Schedule에 추가해 업데이트해주더라도, 남은 자리가 2자리고 동시 신청자가 3명일 경우 여전히 동시성 문제 해결 안됨.
+                     * => 즉 동시성 이슈를 해결할 수 없음!!
+                     */
+                }
+                finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        //then
+        Schedule findSchedule = scheduleRepository.findById(saveSchedule.getScheduleNo()).get();
+        List<ScheduleParticipation> findSP = scheduleParticipationRepository.findBySchedule_ScheduleNo(saveSchedule.getScheduleNo());
+        assertThat(findSP.size()).isEqualTo(1);
+        assertThat(findSchedule.getCurrentVolunteerNum()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("비관적 락을 통해 동시성 문제를 해결해보자.")
+    public void concurrentParticipationWithPERSSIMITIC_WRITE_Lock() throws InterruptedException {
+        //given
+        final int numberOfThreads = 3;
+
+        CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        List<Participant> participants = addTeamMember(numberOfThreads);
+
+        //when
+        for(int i=0;i<numberOfThreads;i++){
+            Participant participant = participants.get(i);
+
+            executorService.execute(() -> {
+                try{
+                    participateService.participateWithPERSSIMITIC_WRITE_Lock(saveRecruitment.getRecruitmentNo(), saveSchedule.getScheduleNo(), participant.getParticipant().getUserNo());
+                }catch (BusinessException e){
+                    log.info("인원 마감 : {}", e.getMessage());
+                    //인원 마감 "INSUFFICIENT_CAPACITY" 예외가 발생해야 함.
+                }
+                finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        //then
+        Schedule findSchedule = scheduleRepository.findById(saveSchedule.getScheduleNo()).get();
+        List<ScheduleParticipation> findSP = scheduleParticipationRepository.findBySchedule_ScheduleNo(saveSchedule.getScheduleNo());
+        assertThat(findSP.size()).isEqualTo(1);
+        assertThat(findSchedule.getCurrentVolunteerNum()).isEqualTo(1);
+    }
+
+
+    private List<Participant> addTeamMember(int num){
+        List<Participant> participants = new ArrayList<>();
+        for(int i=0;i<num;i++){
+            User createUser = User.createUser("test" + i, "test" + i, "test" + i, "test" + i, Gender.M, LocalDate.now(), "picture",
+                    true, true, true, Role.USER, "kakao", "test" + i, null);
+            User saveUser = userRepository.save(createUser);
+
+            Participant createParticipant = Participant.createParticipant(saveRecruitment, saveUser, ParticipantState.JOIN_APPROVAL);
+            Participant saveParticipant = participantRepository.save(createParticipant);
+
+            participants.add(saveParticipant);
+        }
+        return participants;
+    }
+}


### PR DESCRIPTION
close #69 

# 문제 상황
* 일정 신청 간 여러 사용자가 동시에 요청할 경우 요청 사용자 모두 일정에 참여하게 되는 이슈 발생(동시성 이슈)

# 해결 방법
* 낙관적 락 사용하기
  * 일정 엔티티 내 참여 인원 필드 추가 및 Version 관리 필드 추가
  * 데드락 이슈 발생
  
* 비관적 락 사용하기✔
  * 낙관적 락 사용 시 데드락 이슈로 인한 비관적 락 사용
  * 동시성 해결
  * 트래픽 증가 시 성능 이슈 및 데드락 이슈 발생 가능성 존재
  
# 참고 사항
* 자세한 내용은 [동시성 이슈 해결](https://bonsik.tistory.com/9) 블로그를 참고해주시기 바랍니다.ㅎㅎ