### PR TITLE
feat: 봉사 일정 상태별 참여자 리스트 조회 API 기능 구현

### DIFF
--- a/src/main/java/project/volunteer/domain/scheduleParticipation/api/ScheduleParticipantController.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/api/ScheduleParticipantController.java
@@ -3,13 +3,17 @@ package project.volunteer.domain.scheduleParticipation.api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import project.volunteer.domain.scheduleParticipation.api.dto.CancelApproval;
-import project.volunteer.domain.scheduleParticipation.api.dto.CompleteApproval;
+import project.volunteer.domain.scheduleParticipation.api.dto.*;
+import project.volunteer.domain.scheduleParticipation.service.ScheduleParticipationDtoService;
 import project.volunteer.domain.scheduleParticipation.service.ScheduleParticipationService;
+import project.volunteer.domain.scheduleParticipation.service.dto.CancelledParticipantList;
+import project.volunteer.domain.scheduleParticipation.service.dto.CompletedParticipantList;
+import project.volunteer.domain.scheduleParticipation.service.dto.ParticipatingParticipantList;
 import project.volunteer.global.Interceptor.OrganizationAuth;
 import project.volunteer.global.util.SecurityUtil;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +21,7 @@ import javax.validation.Valid;
 public class ScheduleParticipantController {
 
     private final ScheduleParticipationService scheduleParticipationService;
+    private final ScheduleParticipationDtoService scheduleParticipationDtoService;
 
     @OrganizationAuth(auth = OrganizationAuth.Auth.ORGANIZATION_TEAM)
     @PutMapping("/{recruitmentNo}/schedule/{scheduleNo}/join")
@@ -50,5 +55,29 @@ public class ScheduleParticipantController {
 
         scheduleParticipationService.approvalCompletion(scheduleNo, dto.getCompletedList());
         return ResponseEntity.ok().build();
+    }
+
+    @OrganizationAuth(auth = OrganizationAuth.Auth.ORGANIZATION_ADMIN)
+    @GetMapping("/{recruitmentNo}/schedule/{scheduleNo}/participating")
+    public ResponseEntity<ParticipatingParticipantListResponse> scheduleParticipantList(@PathVariable Long recruitmentNo, @PathVariable Long scheduleNo){
+
+        List<ParticipatingParticipantList> participating = scheduleParticipationDtoService.findParticipatingParticipants(scheduleNo);
+        return ResponseEntity.ok(new ParticipatingParticipantListResponse(participating));
+    }
+
+    @OrganizationAuth(auth = OrganizationAuth.Auth.ORGANIZATION_ADMIN)
+    @GetMapping("/{recruitmentNo}/schedule/{scheduleNo}/cancelling")
+    public ResponseEntity<CancelledParticipantListResponse> scheduleCancelledParticipantList(@PathVariable Long recruitmentNo, @PathVariable Long scheduleNo){
+
+        List<CancelledParticipantList> cancellingParticipants = scheduleParticipationDtoService.findCancelledParticipants(scheduleNo);
+        return ResponseEntity.ok(new CancelledParticipantListResponse(cancellingParticipants));
+    }
+
+    @OrganizationAuth(auth = OrganizationAuth.Auth.ORGANIZATION_ADMIN)
+    @GetMapping("/{recruitmentNo}/schedule/{scheduleNo}/completion")
+    public ResponseEntity<CompletedParticipantListResponse> scheduleCompletedParticipantList(@PathVariable Long recruitmentNo, @PathVariable Long scheduleNo){
+
+        List<CompletedParticipantList> completedParticipants = scheduleParticipationDtoService.findCompletedParticipants(scheduleNo);
+        return ResponseEntity.ok(new CompletedParticipantListResponse(completedParticipants));
     }
 }

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/api/dto/CancelledParticipantListResponse.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/api/dto/CancelledParticipantListResponse.java
@@ -1,0 +1,15 @@
+package project.volunteer.domain.scheduleParticipation.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.volunteer.domain.scheduleParticipation.service.dto.CancelledParticipantList;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CancelledParticipantListResponse {
+    List<CancelledParticipantList> cancelling;
+}

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/api/dto/CompletedParticipantListResponse.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/api/dto/CompletedParticipantListResponse.java
@@ -1,0 +1,15 @@
+package project.volunteer.domain.scheduleParticipation.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.volunteer.domain.scheduleParticipation.service.dto.CompletedParticipantList;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CompletedParticipantListResponse {
+    List<CompletedParticipantList> done;
+}

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/api/dto/ParticipatingParticipantListResponse.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/api/dto/ParticipatingParticipantListResponse.java
@@ -1,0 +1,15 @@
+package project.volunteer.domain.scheduleParticipation.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.volunteer.domain.scheduleParticipation.service.dto.ParticipatingParticipantList;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ParticipatingParticipantListResponse {
+    List<ParticipatingParticipantList> participating;
+}

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/dao/ScheduleParticipationRepository.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/dao/ScheduleParticipationRepository.java
@@ -3,6 +3,7 @@ package project.volunteer.domain.scheduleParticipation.dao;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import project.volunteer.domain.scheduleParticipation.dao.dto.ParticipantDetails;
 import project.volunteer.domain.scheduleParticipation.domain.ScheduleParticipation;
 import project.volunteer.global.common.component.ParticipantState;
 
@@ -36,4 +37,19 @@ public interface ScheduleParticipationRepository extends JpaRepository<ScheduleP
 
     Optional<ScheduleParticipation> findByScheduleParticipationNoAndState(Long scheduleParticipationNo, ParticipantState state);
     List<ScheduleParticipation> findByScheduleParticipationNoIn(List<Long> spNos);
+
+    //N+1 문제를 막기 위해서 Projection + Join 방식 사용
+    @Query("select new project.volunteer.domain.scheduleParticipation.dao.dto.ParticipantDetails(u.userNo,u.nickName,u.email,coalesce(s.imagePath,u.picture),sp.state) " +
+            "from ScheduleParticipation sp " +
+            "join sp.participant p " +
+            "join p.participant u " +
+            "left join Image i " +
+            "on i.no=u.userNo " +
+            "and i.realWorkCode=project.volunteer.domain.image.domain.RealWorkCode.USER " +
+            "and i.isDeleted=project.volunteer.global.common.component.IsDeleted.N " +
+            "left join i.storage s " +
+            "where sp.schedule.scheduleNo=:scheduleNo " +
+            "and sp.state in :states ")
+    List<ParticipantDetails> findParticipantsByOptimization(@Param("scheduleNo") Long scheduleNo, @Param("states") List<ParticipantState> states);
+
 }

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/dao/dto/ParticipantDetails.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/dao/dto/ParticipantDetails.java
@@ -1,0 +1,21 @@
+package project.volunteer.domain.scheduleParticipation.dao.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.volunteer.global.common.component.ParticipantState;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ParticipantDetails {
+    Long userNo;
+    String nickname;
+    String email;
+    String profile;
+    ParticipantState state;
+
+    public Boolean isEqualParticipantState(ParticipantState state){
+        return this.state.equals(state);
+    }
+}

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationDtoService.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationDtoService.java
@@ -1,0 +1,19 @@
+package project.volunteer.domain.scheduleParticipation.service;
+
+import project.volunteer.domain.scheduleParticipation.service.dto.CancelledParticipantList;
+import project.volunteer.domain.scheduleParticipation.service.dto.CompletedParticipantList;
+import project.volunteer.domain.scheduleParticipation.service.dto.ParticipatingParticipantList;
+
+import java.util.List;
+
+public interface ScheduleParticipationDtoService {
+
+    //참여 중 참가자 리스트 조회
+    public List<ParticipatingParticipantList> findParticipatingParticipants(Long scheduleNo);
+
+    //취소 요청 참가자 리스트 조회
+    public List<CancelledParticipantList> findCancelledParticipants(Long scheduleNo);
+
+    //참여 완료된(참여 미승인, 참여 승인) 참가자 리스트 조회
+    public List<CompletedParticipantList> findCompletedParticipants(Long scheduleNo);
+}

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationDtoServiceImpl.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationDtoServiceImpl.java
@@ -1,0 +1,66 @@
+package project.volunteer.domain.scheduleParticipation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.volunteer.domain.scheduleParticipation.dao.ScheduleParticipationRepository;
+import project.volunteer.domain.scheduleParticipation.service.dto.CancelledParticipantList;
+import project.volunteer.domain.scheduleParticipation.service.dto.CompletedParticipantList;
+import project.volunteer.domain.scheduleParticipation.service.dto.ParticipatingParticipantList;
+import project.volunteer.domain.sehedule.dao.ScheduleRepository;
+import project.volunteer.global.common.component.ParticipantState;
+import project.volunteer.global.common.response.StateResponse;
+import project.volunteer.global.error.exception.BusinessException;
+import project.volunteer.global.error.exception.ErrorCode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ScheduleParticipationDtoServiceImpl implements ScheduleParticipationDtoService{
+
+    private final ScheduleRepository scheduleRepository;
+    private final ScheduleParticipationRepository scheduleParticipationRepository;
+
+    @Override
+    public List<ParticipatingParticipantList> findParticipatingParticipants(Long scheduleNo) {
+        //일정 조회(삭제되지만 않은)
+        scheduleRepository.findValidSchedule(scheduleNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_SCHEDULE,
+                        String.format("ScheduleNo = [%d]", scheduleNo)));
+
+        return scheduleParticipationRepository.findParticipantsByOptimization(scheduleNo, List.of(ParticipantState.PARTICIPATING)).stream()
+                .map(p -> new ParticipatingParticipantList(p.getNickname(), p.getEmail(), p.getProfile()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CancelledParticipantList> findCancelledParticipants(Long scheduleNo) {
+        //일정 조회(삭제되지만 않은)
+        scheduleRepository.findValidSchedule(scheduleNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_SCHEDULE,
+                        String.format("ScheduleNo = [%d]", scheduleNo)));
+
+        return scheduleParticipationRepository.findParticipantsByOptimization(scheduleNo, List.of(ParticipantState.PARTICIPATION_CANCEL)).stream()
+                .map(p -> new CancelledParticipantList(p.getUserNo(), p.getNickname(), p.getEmail(), p.getProfile()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CompletedParticipantList> findCompletedParticipants(Long scheduleNo) {
+        //일정 조회(삭제되지만 않은)
+        scheduleRepository.findValidSchedule(scheduleNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_SCHEDULE,
+                        String.format("ScheduleNo = [%d]", scheduleNo)));
+
+        return scheduleParticipationRepository.findParticipantsByOptimization(scheduleNo,
+                List.of(ParticipantState.PARTICIPATION_COMPLETE_APPROVAL, ParticipantState.PARTICIPATION_COMPLETE_UNAPPROVED)).stream()
+                .map(sp -> {
+                    StateResponse state = sp.isEqualParticipantState(ParticipantState.PARTICIPATION_COMPLETE_APPROVAL)?(StateResponse.COMPLETE_APPROVED):(StateResponse.COMPLETE_UNAPPROVED);
+                    return new CompletedParticipantList(sp.getUserNo(), sp.getNickname(), sp.getEmail(), sp.getProfile(), state.name());
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationService.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationService.java
@@ -11,5 +11,4 @@ public interface ScheduleParticipationService {
     public void approvalCancellation(Long scheduleNo, Long spNo);
 
     public void approvalCompletion(Long scheduleNo, List<Long> spNo);
-
 }

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationServiceImpl.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationServiceImpl.java
@@ -116,7 +116,6 @@ public class ScheduleParticipationServiceImpl implements ScheduleParticipationSe
                     sp.updateState(ParticipantState.PARTICIPATION_COMPLETE_APPROVAL);
                 });
     }
-
     private Schedule isActiveSchedule(Long scheduleNo){
         //일정 조회(삭제되지 않은지만 검증)
         Schedule findSchedule = scheduleRepository.findValidSchedule(scheduleNo)

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/service/dto/CancelledParticipantList.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/service/dto/CancelledParticipantList.java
@@ -1,0 +1,15 @@
+package project.volunteer.domain.scheduleParticipation.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CancelledParticipantList {
+    Long no;
+    String nickname;
+    String email;
+    String profile;
+}

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/service/dto/CompletedParticipantList.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/service/dto/CompletedParticipantList.java
@@ -1,0 +1,19 @@
+package project.volunteer.domain.scheduleParticipation.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class CompletedParticipantList {
+
+    Long no;
+    String nickname;
+    String email;
+    String profile;
+    String status;
+}

--- a/src/main/java/project/volunteer/domain/scheduleParticipation/service/dto/ParticipatingParticipantList.java
+++ b/src/main/java/project/volunteer/domain/scheduleParticipation/service/dto/ParticipatingParticipantList.java
@@ -1,0 +1,15 @@
+package project.volunteer.domain.scheduleParticipation.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ParticipatingParticipantList {
+
+    String nickname;
+    String email;
+    String profile;
+}

--- a/src/main/java/project/volunteer/global/config/SecurityConfig.java
+++ b/src/main/java/project/volunteer/global/config/SecurityConfig.java
@@ -91,10 +91,16 @@ public class SecurityConfig {
 					.antMatchers(HttpMethod.DELETE, "/recruitment/*/schedule/*").hasAuthority("USER")
 					.antMatchers(HttpMethod.GET, "/recruitment/*/calendar").hasAuthority("USER")
 					.antMatchers(HttpMethod.GET, "/recruitment/*/calendar/*").hasAuthority("USER")
+
+					//일정 신청 관리
 					.antMatchers(HttpMethod.PUT, "/recruitment/*/schedule/*/join").hasAuthority("USER")
 					.antMatchers(HttpMethod.PUT, "/recruitment/*/schedule/*/cancel").hasAuthority("USER")
 					.antMatchers(HttpMethod.PUT, "/recruitment/*/schedule/*/cancelling").hasAuthority("USER")
 					.antMatchers(HttpMethod.PUT, "/recruitment/*/schedule/*/complete").hasAuthority("USER")
+					.antMatchers(HttpMethod.GET, "/recruitment/*/schedule/*/participating").hasAuthority("USER")
+					.antMatchers(HttpMethod.GET, "/recruitment/*/schedule/*/cancelling").hasAuthority("USER")
+					.antMatchers(HttpMethod.GET, "/recruitment/*/schedule/*/completion").hasAuthority("USER")
+
 
 			.anyRequest().permitAll()
 			.and()

--- a/src/test/java/project/volunteer/domain/scheduleParticipation/api/ScheduleParticipantControllerTest.java
+++ b/src/test/java/project/volunteer/domain/scheduleParticipation/api/ScheduleParticipantControllerTest.java
@@ -2,6 +2,7 @@ package project.volunteer.domain.scheduleParticipation.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,10 +10,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import project.volunteer.domain.image.application.ImageService;
+import project.volunteer.domain.image.application.dto.ImageParam;
+import project.volunteer.domain.image.dao.ImageRepository;
+import project.volunteer.domain.image.domain.Image;
+import project.volunteer.domain.image.domain.ImageType;
+import project.volunteer.domain.image.domain.RealWorkCode;
 import project.volunteer.domain.participation.dao.ParticipantRepository;
 import project.volunteer.domain.participation.domain.Participant;
 import project.volunteer.domain.recruitment.dao.RecruitmentRepository;
@@ -27,17 +35,22 @@ import project.volunteer.domain.scheduleParticipation.domain.ScheduleParticipati
 import project.volunteer.domain.scheduleParticipation.service.ScheduleParticipationService;
 import project.volunteer.domain.sehedule.dao.ScheduleRepository;
 import project.volunteer.domain.sehedule.domain.Schedule;
+import project.volunteer.domain.storage.domain.Storage;
 import project.volunteer.domain.user.dao.UserRepository;
 import project.volunteer.domain.user.domain.Gender;
 import project.volunteer.domain.user.domain.Role;
 import project.volunteer.domain.user.domain.User;
 import project.volunteer.global.common.component.*;
+import project.volunteer.global.infra.s3.FileService;
 import project.volunteer.global.test.WithMockCustomUser;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -56,12 +69,16 @@ class ScheduleParticipantControllerTest {
     @Autowired ParticipantRepository participantRepository;
     @Autowired ScheduleParticipationRepository scheduleParticipationRepository;
     @Autowired ScheduleParticipationService spService;
+    @Autowired ImageService imageService;
+    @Autowired ImageRepository imageRepository;
+    @Autowired FileService fileService;
     @Autowired ObjectMapper objectMapper;
 
     private User writer;
     private User loginUser;
     private Recruitment saveRecruitment;
     private Schedule saveSchedule;
+    private List<Long> deleteImageNo = new ArrayList<>();
     @BeforeEach
     void init(){
         //작성자 저장
@@ -91,6 +108,14 @@ class ScheduleParticipantControllerTest {
         User login = User.createUser("test", "test", "test", "test", Gender.M, LocalDate.now(), "test",
                 true, true, true, Role.USER, "kakao", "test", null);
         loginUser = userRepository.save(login);
+    }
+    @AfterEach
+    public void deleteS3Image() { //S3에 테스트를 위해 저장한 이미지 삭제
+        for(Long id : deleteImageNo){
+            Image image = imageRepository.findById(id).get();
+            Storage storage = image.getStorage();
+            fileService.deleteFile(storage.getFakeImageName());
+        }
     }
 
     @Test
@@ -211,7 +236,54 @@ class ScheduleParticipantControllerTest {
                 .andDo(print());
     }
 
+    @Test
+    @DisplayName("일정 참가 중 상태의 참가자 리스트 조회에 성공하다.")
+    @Transactional
+    @WithUserDetails(value = "1234", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    public void participatingParticipantList() throws Exception {
+        //given
+        User test1 = 사용자_등록("test1");
+        Participant participant1 = 봉사모집글_팀원_등록(saveRecruitment, test1);
+        일정_참여상태_추가(saveSchedule, participant1, ParticipantState.PARTICIPATING);
 
+        User test2 = 사용자_등록("test2");
+        Participant participant2 = 봉사모집글_팀원_등록(saveRecruitment, test2);
+        일정_참여상태_추가(saveSchedule, participant2, ParticipantState.PARTICIPATING);
+        clear();
+
+        //when & then
+        mockMvc.perform(get("/recruitment/{recruitmentNo}/schedule/{scheduleNo}/participating", saveRecruitment.getRecruitmentNo(), saveSchedule.getScheduleNo()))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("일정 참가 완료 상태의 참가자 리스트 조회에 성공하다.")
+    @Transactional
+    @WithUserDetails(value = "1234", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    public void completedParticipantList() throws Exception {
+        //given
+        User test1 = 사용자_등록("test1");
+        Participant participant1 = 봉사모집글_팀원_등록(saveRecruitment, test1);
+        일정_참여상태_추가(saveSchedule, participant1, ParticipantState.PARTICIPATION_COMPLETE_APPROVAL);
+
+        User test2 = 사용자_등록("test2");
+        업로드_이미지_등록(test2.getUserNo(), RealWorkCode.USER);
+        Participant participant2 = 봉사모집글_팀원_등록(saveRecruitment, test2);
+        일정_참여상태_추가(saveSchedule, participant2, ParticipantState.PARTICIPATION_COMPLETE_UNAPPROVED);
+        clear();
+
+        //when & then
+        mockMvc.perform(get("/recruitment/{recruitmentNo}/schedule/{scheduleNo}/completion", saveRecruitment.getRecruitmentNo(), saveSchedule.getScheduleNo()))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    private User 사용자_등록(String username){
+        User createUser = User.createUser(username, username, username, username, Gender.M, LocalDate.now(), "picture",
+                true, true, true, Role.USER, "kakao", username, null);
+        return userRepository.save(createUser);
+    }
     private Participant 봉사모집글_팀원_등록(Recruitment recruitment, User user){
         Participant participant = Participant.createParticipant(recruitment, user, ParticipantState.JOIN_APPROVAL);
         return participantRepository.save(participant);
@@ -226,5 +298,20 @@ class ScheduleParticipantControllerTest {
     }
     private <T> String toJson(T data) throws JsonProcessingException {
         return objectMapper.writeValueAsString(data);
+    }
+    private void 업로드_이미지_등록(Long no, RealWorkCode code) throws IOException {
+        ImageParam imageDto = ImageParam.builder()
+                .code(code)
+                .imageType(ImageType.UPLOAD)
+                .no(no)
+                .staticImageCode(null)
+                .uploadImage(getMockMultipartFile())
+                .build();
+        Long imageNo = imageService.addImage(imageDto);
+        deleteImageNo.add(imageNo);
+    }
+    private MockMultipartFile getMockMultipartFile() throws IOException {
+        return new MockMultipartFile(
+                "file", "file.PNG", "image/jpg", new FileInputStream("src/main/resources/static/test/file.PNG"));
     }
 }

--- a/src/test/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationDtoServiceImplTest.java
+++ b/src/test/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationDtoServiceImplTest.java
@@ -1,0 +1,187 @@
+package project.volunteer.domain.scheduleParticipation.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import project.volunteer.domain.participation.dao.ParticipantRepository;
+import project.volunteer.domain.participation.domain.Participant;
+import project.volunteer.domain.recruitment.dao.RecruitmentRepository;
+import project.volunteer.domain.recruitment.domain.Recruitment;
+import project.volunteer.domain.recruitment.domain.VolunteerType;
+import project.volunteer.domain.recruitment.domain.VolunteeringCategory;
+import project.volunteer.domain.recruitment.domain.VolunteeringType;
+import project.volunteer.domain.scheduleParticipation.dao.ScheduleParticipationRepository;
+import project.volunteer.domain.scheduleParticipation.domain.ScheduleParticipation;
+import project.volunteer.domain.scheduleParticipation.service.dto.CancelledParticipantList;
+import project.volunteer.domain.scheduleParticipation.service.dto.CompletedParticipantList;
+import project.volunteer.domain.scheduleParticipation.service.dto.ParticipatingParticipantList;
+import project.volunteer.domain.sehedule.dao.ScheduleRepository;
+import project.volunteer.domain.sehedule.domain.Schedule;
+import project.volunteer.domain.user.dao.UserRepository;
+import project.volunteer.domain.user.domain.Gender;
+import project.volunteer.domain.user.domain.Role;
+import project.volunteer.domain.user.domain.User;
+import project.volunteer.global.common.component.*;
+import project.volunteer.global.common.response.StateResponse;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+class ScheduleParticipationDtoServiceImplTest {
+
+    @PersistenceContext
+    EntityManager em;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    RecruitmentRepository recruitmentRepository;
+    @Autowired
+    ScheduleRepository scheduleRepository;
+    @Autowired
+    ParticipantRepository participantRepository;
+    @Autowired
+    ScheduleParticipationRepository scheduleParticipationRepository;
+    @Autowired ScheduleParticipationDtoService spDtoService;
+
+    private User writer;
+    private Recruitment saveRecruitment;
+    private Schedule saveSchedule;
+    @BeforeEach
+    void init(){
+        //작성자 저장
+        User writerUser = User.createUser("1234", "1234", "1234", "1234", Gender.M, LocalDate.now(), "1234",
+                true, true, true, Role.USER, "kakao", "1234", null);
+        writer = userRepository.save(writerUser);
+
+        //모집글 저장
+        Recruitment createRecruitment = Recruitment.createRecruitment("title", "content", VolunteeringCategory.CULTURAL_EVENT, VolunteeringType.IRREG,
+                VolunteerType.TEENAGER, 3, true, "organization",
+                Address.createAddress("11", "1111","details"), Coordinate.createCoordinate(3.2F, 3.2F),
+                Timetable.createTimetable(LocalDate.now(), LocalDate.now().plusMonths(3), HourFormat.AM, LocalTime.now(), 3), true);
+        createRecruitment.setWriter(writer);
+        saveRecruitment = recruitmentRepository.save(createRecruitment);
+
+        //일정 저장
+        Schedule createSchedule = Schedule.createSchedule(
+                Timetable.createTimetable(
+                        LocalDate.now().plusMonths(1), LocalDate.now().plusMonths(1),
+                        HourFormat.AM, LocalTime.now(), 3),
+                "content", "organization",
+                Address.createAddress("11", "1111", "details"), 3);
+        createSchedule.setRecruitment(saveRecruitment);
+        saveSchedule = scheduleRepository.save(createSchedule);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("일정 참여 중 리스트 조회 시 3명의 참여자가 조회된다.")
+    public void schedule_participant_list(){
+        //given
+        User newUser1 = 사용자_등록("구본식");
+        Participant newParticipant1 = 봉사모집글_팀원_등록(saveRecruitment, newUser1);
+        일정_참여자_상태_추가(saveSchedule, newParticipant1, ParticipantState.PARTICIPATING);
+
+        User newUser2 = 사용자_등록("양소은");
+        Participant newParticipant2 = 봉사모집글_팀원_등록(saveRecruitment, newUser2);
+        일정_참여자_상태_추가(saveSchedule, newParticipant2, ParticipantState.PARTICIPATING);
+
+        User newUser3 = 사용자_등록("양호록");
+        Participant newParticipant3 = 봉사모집글_팀원_등록(saveRecruitment, newUser3);
+        일정_참여자_상태_추가(saveSchedule, newParticipant3, ParticipantState.PARTICIPATING);
+        clear();
+
+        //when
+        List<ParticipatingParticipantList> findParticipants = spDtoService.findParticipatingParticipants(saveSchedule.getScheduleNo());
+
+        //then
+        assertThat(findParticipants.size()).isEqualTo(3);
+        for(ParticipatingParticipantList p : findParticipants){
+            assertThat(p.getProfile()).isEqualTo("picture");
+        }
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("일정 취소 요청 리스트 조회 시 2명의 취소 요청자가 조회된다.")
+    public void schedule_cancel_participant_list(){
+        //given
+        User newUser1 = 사용자_등록("구본식");
+        Participant newParticipant1 = 봉사모집글_팀원_등록(saveRecruitment, newUser1);
+        일정_참여자_상태_추가(saveSchedule, newParticipant1, ParticipantState.PARTICIPATING);
+
+        User newUser2 = 사용자_등록("양소은");
+        Participant newParticipant2 = 봉사모집글_팀원_등록(saveRecruitment, newUser2);
+        일정_참여자_상태_추가(saveSchedule, newParticipant2, ParticipantState.PARTICIPATION_CANCEL);
+
+        User newUser3 = 사용자_등록("양호록");
+        Participant newParticipant3 = 봉사모집글_팀원_등록(saveRecruitment, newUser3);
+        일정_참여자_상태_추가(saveSchedule, newParticipant3, ParticipantState.PARTICIPATION_CANCEL);
+        clear();
+
+        //when
+        List<CancelledParticipantList> findCancellingParticipants = spDtoService.findCancelledParticipants(saveSchedule.getScheduleNo());
+
+
+        //then
+        assertThat(findCancellingParticipants.size()).isEqualTo(2);
+        for(CancelledParticipantList p : findCancellingParticipants){
+            assertThat(p.getProfile()).isEqualTo("picture");
+        }
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("일정 참여 완료 리스트 조회 시 2명의 참여 완료 미승인과 1명의 참여 완료 승인자가 조회된다.")
+    public void schedule_completed_participant_list(){
+        //given
+        User newUser1 = 사용자_등록("구본식");
+        Participant newParticipant1 = 봉사모집글_팀원_등록(saveRecruitment, newUser1);
+        일정_참여자_상태_추가(saveSchedule, newParticipant1, ParticipantState.PARTICIPATION_COMPLETE_UNAPPROVED);
+
+        User newUser2 = 사용자_등록("양소은");
+        Participant newParticipant2 = 봉사모집글_팀원_등록(saveRecruitment, newUser2);
+        일정_참여자_상태_추가(saveSchedule, newParticipant2, ParticipantState.PARTICIPATION_COMPLETE_UNAPPROVED);
+
+        User newUser3 = 사용자_등록("양호록");
+        Participant newParticipant3 = 봉사모집글_팀원_등록(saveRecruitment, newUser3);
+        일정_참여자_상태_추가(saveSchedule, newParticipant3, ParticipantState.PARTICIPATION_COMPLETE_APPROVAL);
+        clear();
+
+        //when
+        List<CompletedParticipantList> findCompletedParticipants = spDtoService.findCompletedParticipants(saveSchedule.getScheduleNo());
+
+        //then
+        assertThat(findCompletedParticipants.size()).isEqualTo(3);
+        for(CompletedParticipantList p : findCompletedParticipants){
+            assertThat(p.getProfile()).isEqualTo("picture");
+            assertThat(p.getStatus()).isIn(StateResponse.COMPLETE_APPROVED.name(), StateResponse.COMPLETE_UNAPPROVED.name());
+        }
+    }
+
+    private User 사용자_등록(String username){
+        User createUser = User.createUser(username, username, username, username, Gender.M, LocalDate.now(), "picture",
+                true, true, true, Role.USER, "kakao", username, null);
+        return userRepository.save(createUser);
+    }
+    private Participant 봉사모집글_팀원_등록(Recruitment recruitment, User user){
+        Participant participant = Participant.createParticipant(recruitment, user, ParticipantState.JOIN_APPROVAL);
+        return participantRepository.save(participant);
+    }
+    private ScheduleParticipation 일정_참여자_상태_추가(Schedule schedule, Participant participant, ParticipantState state){
+        ScheduleParticipation scheduleParticipation = ScheduleParticipation.createScheduleParticipation(schedule, participant, state);
+        return scheduleParticipationRepository.save(scheduleParticipation);
+    }
+    private void clear() {
+        em.flush();
+        em.clear();
+    }
+}

--- a/src/test/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationServiceImplTest.java
+++ b/src/test/java/project/volunteer/domain/scheduleParticipation/service/ScheduleParticipationServiceImplTest.java
@@ -165,7 +165,7 @@ class ScheduleParticipationServiceImplTest {
         //given
         User newUser = 사용자_등록("구본식");
         Participant newParticipant = 봉사모집글_팀원_등록(saveRecruitment, newUser);
-        일정_참여자_상태_추가(saveSchedule, newParticipant, ParticipantState.PARTICIPATION_CANCEL);
+        일정_참여자_상태_추가(saveSchedule, newParticipant, ParticipantState.PARTICIPATION_CANCEL_APPROVAL);
         clear();
 
         //when
@@ -278,7 +278,6 @@ class ScheduleParticipationServiceImplTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.INVALID_STATE.name());
     }
-
 
     private User 사용자_등록(String username){
         User createUser = User.createUser(username, username, username, username, Gender.M, LocalDate.now(), "picture",


### PR DESCRIPTION
close #56 

# 구현 사항
* 봉사 일정 상태 별(참여 중, 참여 취소 요청, 참여 완료) 참여자 리스트 조회 

# 집중적으로 피드백 받고 싶은 부분
* 참여 중, 참여 취소 요청, 참여 완료(참여 완료 미승인, 승인) 상태 별 별도의 쿼리를 만드는 대신 하나의**findParticipantsByOptimization** 쿼리 메소드를 사용했습니다.
또한, 사용자 정보(닉네임, 이메일 등)와 간접 참조를 사용하는 이미지 테이블의 N+1 문제를 해결하고자 Projection + JOIN을 통해 DTO를 반환하도록 구현했습니다.
참여 중, 참여 취소 요청, 참여 완료 상태의  참가자 리스트 조회 각 Service 기능은 **findParticipantsByOptimization** 쿼리 메소드 호출을 동일하게 하고 차이점은 **Response DTO** 반환값이 다르다는 점입니다.
현재는 **findParticipantsByOptimization** 쿼리 메소드가 결국 엔티티가 아닌 DTO를 리턴하기 때문에, 각 상태별 참여자 리스트 조회 Service를 DTO 전용으로 만들었고 Service에서 응답 DTO를 가공하는 방식을 사용했습니다.
생각한 다른 방식으로는, 레포지토리에서 DTO를 반환하긴 하지만 상태 별 조회 서비스를 하나로 통합하여 재사용하고 Controller에서 Response DTO 스펙에 맞게 가공하는 방식을 사용할 수도 있을 거 같습니다.
진우님은 어떤 방향이 더 좋은 설계라고 생각하나요???
