### PR TITLE
fix: 봉사 상세 조회 시 DTO 필드 누락

### DIFF
--- a/src/main/java/project/volunteer/DummyConfig.java
+++ b/src/main/java/project/volunteer/DummyConfig.java
@@ -27,7 +27,7 @@ public class DummyConfig {
     private final ScheduleParticipationRepository scheduleParticipationRepository;
 
     @Bean
-    @Profile("prod")
+//    @Profile("prod")
     public DummyDataInit dummyDataInit(){
         return new DummyDataInit(userRepository, recruitmentRepository, repeatPeriodRepository, imageRepository, storageRepository,participantRepository,
                 scheduleRepository, scheduleParticipationRepository);

--- a/src/main/java/project/volunteer/domain/recruitment/dao/queryDto/RecruitmentQueryDtoRepositoryImpl.java
+++ b/src/main/java/project/volunteer/domain/recruitment/dao/queryDto/RecruitmentQueryDtoRepositoryImpl.java
@@ -74,7 +74,7 @@ public class RecruitmentQueryDtoRepositoryImpl implements RecruitmentQueryDtoRep
         List<RecruitmentListQuery> content = jpaQueryFactory
                 .select(
                         new QRecruitmentListQuery(recruitment.recruitmentNo, recruitment.volunteeringCategory,recruitment.title,
-                                recruitment.address.sido, recruitment.address.sigungu,
+                                recruitment.address.sido, recruitment.address.sigungu, recruitment.address.fullName,
                                 recruitment.VolunteeringTimeTable.startDay, recruitment.VolunteeringTimeTable.endDay, recruitment.volunteeringType,
                                 recruitment.volunteerType, recruitment.isIssued, recruitment.volunteerNum, storage.imagePath))
                 .from(recruitment)

--- a/src/test/java/project/volunteer/global/jwt/util/JwtProviderTest.java
+++ b/src/test/java/project/volunteer/global/jwt/util/JwtProviderTest.java
@@ -1,0 +1,23 @@
+package project.volunteer.global.jwt.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import project.volunteer.global.jwt.dto.JwtToken;
+
+@SpringBootTest
+class JwtProviderTest {
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+    @Test
+    void test() {
+        JwtToken jwtToken = jwtProvider.createJwtToken("11111");
+        System.out.println(jwtToken.getAccessToken());
+
+        JwtToken jwtToken1 = jwtProvider.createJwtToken("10000");
+        System.out.println(jwtToken1.getAccessToken());
+    }
+
+}


### PR DESCRIPTION
# 구현 사항
* 봉사 상세 조회 시, QueryDSL Projection 누락 필드 추가
* 로컬 환경에서도 더미 데이터 설정 방식으로 변경